### PR TITLE
Add provider-agnostic receipt scanning with feature flag

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,11 +24,11 @@
     "./trpc": "./src/routers/index.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.102.0",
     "@fin-health/shared": "*",
-    "@trpc/server": "^11.0.0",
-    "superjson": "^1.13.3",
     "@prisma/client": "^6.4.1",
     "@sentry/node": "^10.42.0",
+    "@trpc/server": "^11.0.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "csv-stringify": "^6.5.2",
@@ -39,9 +39,11 @@
     "helmet": "^8.0.0",
     "i18next": "^25.8.14",
     "jsonwebtoken": "^9.0.2",
+    "openai": "^6.42.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",
     "stripe": "^20.4.1",
+    "superjson": "^1.13.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -66,7 +66,7 @@ app.post(
   },
 );
 
-app.use(express.json({ limit: '1mb' }));
+app.use(express.json({ limit: '10mb' }));
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,

--- a/backend/src/lib/env.ts
+++ b/backend/src/lib/env.ts
@@ -18,6 +18,10 @@ const envSchema = z.object({
     .enum(['true', 'false'])
     .default('true')
     .transform((v) => v === 'true'),
+  RECEIPT_PROVIDER: z.enum(['anthropic', 'openai', 'qwen']).default('anthropic'),
+  ANTHROPIC_API_KEY: z.string().default(''),
+  OPENAI_API_KEY: z.string().default(''),
+  DASHSCOPE_API_KEY: z.string().default(''),
 });
 
 export const env = envSchema.parse(process.env);

--- a/backend/src/lib/env.ts
+++ b/backend/src/lib/env.ts
@@ -18,6 +18,7 @@ const envSchema = z.object({
     .enum(['true', 'false'])
     .default('true')
     .transform((v) => v === 'true'),
+  FEATURE_RECEIPT_SCANNING: z.coerce.boolean().default(false),
   RECEIPT_PROVIDER: z.enum(['anthropic', 'openai', 'qwen']).default('anthropic'),
   ANTHROPIC_API_KEY: z.string().default(''),
   OPENAI_API_KEY: z.string().default(''),

--- a/backend/src/routers/auth.ts
+++ b/backend/src/routers/auth.ts
@@ -21,7 +21,7 @@ const FREE_PLAN: UserPlan = {
 };
 
 function featureFlags(): FeatureFlags {
-  return { billing: env.BILLING_ENABLED };
+  return { billing: env.BILLING_ENABLED, receiptScanning: env.FEATURE_RECEIPT_SCANNING };
 }
 
 // Precomputed bcrypt hash (cost 12) of an arbitrary password, used to run a

--- a/backend/src/routers/index.ts
+++ b/backend/src/routers/index.ts
@@ -6,6 +6,7 @@ import { budgetsRouter } from './budgets';
 import { recurringRouter } from './recurring';
 import { dashboardRouter } from './dashboard';
 import { billingRouter } from './billing';
+import { receiptsRouter } from './receipts';
 
 export const appRouter = router({
   auth: authRouter,
@@ -15,6 +16,7 @@ export const appRouter = router({
   recurring: recurringRouter,
   dashboard: dashboardRouter,
   billing: billingRouter,
+  receipts: receiptsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/backend/src/routers/receipts.test.ts
+++ b/backend/src/routers/receipts.test.ts
@@ -1,24 +1,33 @@
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
 import { createTestUser, callerFor, cleanupUser, type TestUser } from '../test/helpers';
 import prisma from '../lib/prisma';
+import { env } from '../lib/env';
 
-// Mutable env object — individual tests flip FEATURE_RECEIPT_SCANNING as needed
-const mockEnv = {
-  FEATURE_RECEIPT_SCANNING: true,
-  RECEIPT_PROVIDER: 'anthropic' as const,
-  ANTHROPIC_API_KEY: 'test-key',
-  OPENAI_API_KEY: '',
-  DASHSCOPE_API_KEY: '',
-  // passthrough fields the router doesn't use but env module exports
-  BILLING_ENABLED: true,
-};
+const { envOverrides, mockScan } = vi.hoisted(() => ({
+  envOverrides: {
+    FEATURE_RECEIPT_SCANNING: true,
+    RECEIPT_PROVIDER: 'anthropic' as const,
+    ANTHROPIC_API_KEY: 'test-key',
+    OPENAI_API_KEY: '',
+    DASHSCOPE_API_KEY: '',
+  },
+  mockScan: vi.fn(),
+}));
 
-vi.mock('../lib/env', () => ({ env: mockEnv }));
-
-const mockScan = vi.fn();
+vi.mock('../lib/env', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/env')>();
+  return { env: Object.assign(actual.env, envOverrides) };
+});
 
 vi.mock('../services/receiptScanner', () => ({
-  getReceiptProvider: vi.fn().mockResolvedValue({ scan: mockScan }),
+  getReceiptProvider: vi.fn().mockImplementation(() => {
+    if (!envOverrides.ANTHROPIC_API_KEY) {
+      return Promise.reject(
+        new Error('ANTHROPIC_API_KEY is required for the anthropic receipt provider'),
+      );
+    }
+    return Promise.resolve({ scan: mockScan });
+  }),
   RECEIPT_PROMPT: 'test prompt',
 }));
 
@@ -70,13 +79,14 @@ describe('receipts.scan', () => {
   });
 
   beforeEach(() => {
-    mockEnv.FEATURE_RECEIPT_SCANNING = true;
-    mockEnv.ANTHROPIC_API_KEY = 'test-key';
+    (env as any).FEATURE_RECEIPT_SCANNING = true;
+    (env as any).ANTHROPIC_API_KEY = 'test-key';
+    envOverrides.ANTHROPIC_API_KEY = 'test-key';
     mockScan.mockReset();
   });
 
   it('throws FORBIDDEN when feature flag is off', async () => {
-    mockEnv.FEATURE_RECEIPT_SCANNING = false;
+    (env as any).FEATURE_RECEIPT_SCANNING = false;
     const caller = await callerFor(proUser);
 
     await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({
@@ -104,7 +114,8 @@ describe('receipts.scan', () => {
   });
 
   it('throws INTERNAL_SERVER_ERROR when no API key is configured', async () => {
-    mockEnv.ANTHROPIC_API_KEY = '';
+    (env as any).ANTHROPIC_API_KEY = '';
+    envOverrides.ANTHROPIC_API_KEY = '';
     const caller = await callerFor(proUser);
 
     await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({

--- a/backend/src/routers/receipts.test.ts
+++ b/backend/src/routers/receipts.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
+import { createTestUser, callerFor, cleanupUser, type TestUser } from '../test/helpers';
+import prisma from '../lib/prisma';
+
+// Mutable env object — individual tests flip FEATURE_RECEIPT_SCANNING as needed
+const mockEnv = {
+  FEATURE_RECEIPT_SCANNING: true,
+  RECEIPT_PROVIDER: 'anthropic' as const,
+  ANTHROPIC_API_KEY: 'test-key',
+  OPENAI_API_KEY: '',
+  DASHSCOPE_API_KEY: '',
+  // passthrough fields the router doesn't use but env module exports
+  BILLING_ENABLED: true,
+};
+
+vi.mock('../lib/env', () => ({ env: mockEnv }));
+
+const mockScan = vi.fn();
+
+vi.mock('../services/receiptScanner', () => ({
+  getReceiptProvider: vi.fn().mockResolvedValue({ scan: mockScan }),
+  RECEIPT_PROMPT: 'test prompt',
+}));
+
+const VALID_INPUT = {
+  imageBase64: 'dGVzdA==',
+  mimeType: 'image/jpeg' as const,
+};
+
+const SCAN_RESULT = {
+  merchant: 'Test Store',
+  amount: '42.50',
+  currency: 'USD',
+  date: '2026-06-09',
+  type: 'expense' as const,
+  description: 'Grocery shopping',
+  categoryName: 'Food & Dining',
+  confidence: 'high' as const,
+};
+
+async function createProUser(): Promise<TestUser> {
+  const user = await createTestUser();
+  await prisma.subscription.create({
+    data: {
+      userId: user.id,
+      plan: 'pro',
+      status: 'active',
+      stripeCustomerId: `cus_test_${user.id}`,
+      stripeSubscriptionId: `sub_test_${user.id}`,
+      cancelAtPeriodEnd: false,
+      trialEndsAt: null,
+      currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    },
+  });
+  return user;
+}
+
+describe('receipts.scan', () => {
+  let freeUser: TestUser;
+  let proUser: TestUser;
+
+  beforeAll(async () => {
+    freeUser = await createTestUser();
+    proUser = await createProUser();
+  });
+
+  afterAll(async () => {
+    await cleanupUser(freeUser.id);
+    await cleanupUser(proUser.id);
+  });
+
+  beforeEach(() => {
+    mockEnv.FEATURE_RECEIPT_SCANNING = true;
+    mockEnv.ANTHROPIC_API_KEY = 'test-key';
+    mockScan.mockReset();
+  });
+
+  it('throws FORBIDDEN when feature flag is off', async () => {
+    mockEnv.FEATURE_RECEIPT_SCANNING = false;
+    const caller = await callerFor(proUser);
+
+    await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'RECEIPT_SCANNING_DISABLED',
+    });
+  });
+
+  it('throws FORBIDDEN for unauthenticated request', async () => {
+    const { publicCaller } = await import('../test/helpers.js');
+    const caller = publicCaller();
+
+    await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('throws FORBIDDEN for free user (Pro required)', async () => {
+    const caller = await callerFor(freeUser);
+
+    await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'PRO_REQUIRED',
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when no API key is configured', async () => {
+    mockEnv.ANTHROPIC_API_KEY = '';
+    const caller = await callerFor(proUser);
+
+    await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Receipt scanning is not configured',
+    });
+  });
+
+  it('throws INTERNAL_SERVER_ERROR when the provider fails', async () => {
+    mockScan.mockRejectedValueOnce(new Error('Provider API timeout'));
+    const caller = await callerFor(proUser);
+
+    await expect(caller.receipts.scan(VALID_INPUT)).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to parse receipt. Please try a clearer image.',
+    });
+  });
+
+  it('returns scan result for Pro user with valid image', async () => {
+    mockScan.mockResolvedValueOnce(SCAN_RESULT);
+    const caller = await callerFor(proUser);
+
+    const { result } = await caller.receipts.scan(VALID_INPUT);
+
+    expect(result.merchant).toBe('Test Store');
+    expect(result.amount).toBe('42.50');
+    expect(result.currency).toBe('USD');
+    expect(result.type).toBe('expense');
+    expect(result.confidence).toBe('high');
+  });
+});

--- a/backend/src/routers/receipts.ts
+++ b/backend/src/routers/receipts.ts
@@ -10,20 +10,18 @@ export const receiptsRouter = router({
       throw new TRPCError({ code: 'FORBIDDEN', message: 'RECEIPT_SCANNING_DISABLED' });
     }
 
-    const hasKey =
-      (env.RECEIPT_PROVIDER === 'anthropic' && env.ANTHROPIC_API_KEY) ||
-      (env.RECEIPT_PROVIDER === 'openai' && env.OPENAI_API_KEY) ||
-      (env.RECEIPT_PROVIDER === 'qwen' && env.DASHSCOPE_API_KEY);
-
-    if (!hasKey) {
+    let provider;
+    try {
+      provider = await getReceiptProvider();
+    } catch (err) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Receipt scanning is not configured',
+        cause: err,
       });
     }
 
     try {
-      const provider = await getReceiptProvider();
       const result = await provider.scan(input.imageBase64, input.mimeType);
       return { result };
     } catch (err) {

--- a/backend/src/routers/receipts.ts
+++ b/backend/src/routers/receipts.ts
@@ -1,0 +1,34 @@
+import { TRPCError } from '@trpc/server';
+import { router, proProcedure } from '../trpc';
+import { scanReceiptInputSchema } from '@fin-health/shared';
+import { getReceiptProvider } from '../services/receiptScanner';
+import { env } from '../lib/env';
+
+export const receiptsRouter = router({
+  scan: proProcedure.input(scanReceiptInputSchema).mutation(async ({ input }) => {
+    const hasKey =
+      (env.RECEIPT_PROVIDER === 'anthropic' && env.ANTHROPIC_API_KEY) ||
+      (env.RECEIPT_PROVIDER === 'openai' && env.OPENAI_API_KEY) ||
+      (env.RECEIPT_PROVIDER === 'qwen' && env.DASHSCOPE_API_KEY);
+
+    if (!hasKey) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Receipt scanning is not configured',
+      });
+    }
+
+    try {
+      const provider = await getReceiptProvider();
+      const result = await provider.scan(input.imageBase64, input.mimeType);
+      return { result };
+    } catch (err) {
+      if (err instanceof TRPCError) throw err;
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse receipt. Please try a clearer image.',
+        cause: err,
+      });
+    }
+  }),
+});

--- a/backend/src/routers/receipts.ts
+++ b/backend/src/routers/receipts.ts
@@ -6,6 +6,10 @@ import { env } from '../lib/env';
 
 export const receiptsRouter = router({
   scan: proProcedure.input(scanReceiptInputSchema).mutation(async ({ input }) => {
+    if (!env.FEATURE_RECEIPT_SCANNING) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: 'RECEIPT_SCANNING_DISABLED' });
+    }
+
     const hasKey =
       (env.RECEIPT_PROVIDER === 'anthropic' && env.ANTHROPIC_API_KEY) ||
       (env.RECEIPT_PROVIDER === 'openai' && env.OPENAI_API_KEY) ||

--- a/backend/src/services/receipt-providers/anthropic.ts
+++ b/backend/src/services/receipt-providers/anthropic.ts
@@ -1,0 +1,42 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { receiptScanResultSchema, type ReceiptScanResult } from '@fin-health/shared';
+import { env } from '../../lib/env';
+import type { ReceiptProvider } from '../receiptScanner';
+import { RECEIPT_PROMPT } from '../receiptScanner';
+
+export class AnthropicReceiptProvider implements ReceiptProvider {
+  private client: Anthropic;
+
+  constructor() {
+    if (!env.ANTHROPIC_API_KEY) {
+      throw new Error('ANTHROPIC_API_KEY is required for the anthropic receipt provider');
+    }
+    this.client = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+  }
+
+  async scan(imageBase64: string, mimeType: string): Promise<ReceiptScanResult> {
+    const response = await this.client.messages.create({
+      model: 'claude-haiku-4-5',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: mimeType as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+                data: imageBase64,
+              },
+            },
+            { type: 'text', text: RECEIPT_PROMPT },
+          ],
+        },
+      ],
+    });
+
+    const text = response.content.find((b) => b.type === 'text')?.text ?? '';
+    return receiptScanResultSchema.parse(JSON.parse(text));
+  }
+}

--- a/backend/src/services/receipt-providers/anthropic.ts
+++ b/backend/src/services/receipt-providers/anthropic.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { receiptScanResultSchema, type ReceiptScanResult } from '@fin-health/shared';
 import { env } from '../../lib/env';
 import type { ReceiptProvider } from '../receiptScanner';
-import { RECEIPT_PROMPT } from '../receiptScanner';
+import { RECEIPT_PROMPT, parseReceiptJson } from '../receiptScanner';
 
 export class AnthropicReceiptProvider implements ReceiptProvider {
   private client: Anthropic;
@@ -37,6 +37,6 @@ export class AnthropicReceiptProvider implements ReceiptProvider {
     });
 
     const text = response.content.find((b) => b.type === 'text')?.text ?? '';
-    return receiptScanResultSchema.parse(JSON.parse(text));
+    return receiptScanResultSchema.parse(parseReceiptJson(text));
   }
 }

--- a/backend/src/services/receipt-providers/openai.ts
+++ b/backend/src/services/receipt-providers/openai.ts
@@ -2,7 +2,7 @@ import OpenAI from 'openai';
 import { receiptScanResultSchema, type ReceiptScanResult } from '@fin-health/shared';
 import { env } from '../../lib/env';
 import type { ReceiptProvider } from '../receiptScanner';
-import { RECEIPT_PROMPT } from '../receiptScanner';
+import { RECEIPT_PROMPT, parseReceiptJson } from '../receiptScanner';
 
 export class OpenAIReceiptProvider implements ReceiptProvider {
   private client: OpenAI;
@@ -33,6 +33,6 @@ export class OpenAIReceiptProvider implements ReceiptProvider {
     });
 
     const text = response.choices[0]?.message?.content ?? '';
-    return receiptScanResultSchema.parse(JSON.parse(text));
+    return receiptScanResultSchema.parse(parseReceiptJson(text));
   }
 }

--- a/backend/src/services/receipt-providers/openai.ts
+++ b/backend/src/services/receipt-providers/openai.ts
@@ -1,0 +1,38 @@
+import OpenAI from 'openai';
+import { receiptScanResultSchema, type ReceiptScanResult } from '@fin-health/shared';
+import { env } from '../../lib/env';
+import type { ReceiptProvider } from '../receiptScanner';
+import { RECEIPT_PROMPT } from '../receiptScanner';
+
+export class OpenAIReceiptProvider implements ReceiptProvider {
+  private client: OpenAI;
+
+  constructor() {
+    if (!env.OPENAI_API_KEY) {
+      throw new Error('OPENAI_API_KEY is required for the openai receipt provider');
+    }
+    this.client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+  }
+
+  async scan(imageBase64: string, mimeType: string): Promise<ReceiptScanResult> {
+    const response = await this.client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url: `data:${mimeType};base64,${imageBase64}` },
+            },
+            { type: 'text', text: RECEIPT_PROMPT },
+          ],
+        },
+      ],
+    });
+
+    const text = response.choices[0]?.message?.content ?? '';
+    return receiptScanResultSchema.parse(JSON.parse(text));
+  }
+}

--- a/backend/src/services/receipt-providers/qwen.ts
+++ b/backend/src/services/receipt-providers/qwen.ts
@@ -2,7 +2,7 @@ import OpenAI from 'openai';
 import { receiptScanResultSchema, type ReceiptScanResult } from '@fin-health/shared';
 import { env } from '../../lib/env';
 import type { ReceiptProvider } from '../receiptScanner';
-import { RECEIPT_PROMPT } from '../receiptScanner';
+import { RECEIPT_PROMPT, parseReceiptJson } from '../receiptScanner';
 
 export class QwenReceiptProvider implements ReceiptProvider {
   private client: OpenAI;
@@ -36,6 +36,6 @@ export class QwenReceiptProvider implements ReceiptProvider {
     });
 
     const text = response.choices[0]?.message?.content ?? '';
-    return receiptScanResultSchema.parse(JSON.parse(text));
+    return receiptScanResultSchema.parse(parseReceiptJson(text));
   }
 }

--- a/backend/src/services/receipt-providers/qwen.ts
+++ b/backend/src/services/receipt-providers/qwen.ts
@@ -1,0 +1,41 @@
+import OpenAI from 'openai';
+import { receiptScanResultSchema, type ReceiptScanResult } from '@fin-health/shared';
+import { env } from '../../lib/env';
+import type { ReceiptProvider } from '../receiptScanner';
+import { RECEIPT_PROMPT } from '../receiptScanner';
+
+export class QwenReceiptProvider implements ReceiptProvider {
+  private client: OpenAI;
+
+  constructor() {
+    if (!env.DASHSCOPE_API_KEY) {
+      throw new Error('DASHSCOPE_API_KEY is required for the qwen receipt provider');
+    }
+    this.client = new OpenAI({
+      apiKey: env.DASHSCOPE_API_KEY,
+      baseURL: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+    });
+  }
+
+  async scan(imageBase64: string, mimeType: string): Promise<ReceiptScanResult> {
+    const response = await this.client.chat.completions.create({
+      model: 'qwen-vl-max',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url: `data:${mimeType};base64,${imageBase64}` },
+            },
+            { type: 'text', text: RECEIPT_PROMPT },
+          ],
+        },
+      ],
+    });
+
+    const text = response.choices[0]?.message?.content ?? '';
+    return receiptScanResultSchema.parse(JSON.parse(text));
+  }
+}

--- a/backend/src/services/receiptScanner.ts
+++ b/backend/src/services/receiptScanner.ts
@@ -1,0 +1,46 @@
+import type { ReceiptScanResult } from '@fin-health/shared';
+import { env } from '../lib/env';
+
+export interface ReceiptProvider {
+  scan(imageBase64: string, mimeType: string): Promise<ReceiptScanResult>;
+}
+
+export const RECEIPT_PROMPT = `You are a receipt parser. Extract information from this receipt image and return ONLY a valid JSON object with these exact fields:
+
+{
+  "merchant": "store/restaurant/service name",
+  "amount": "total amount as a string, e.g. '42.50'",
+  "currency": "ISO 4217 3-letter code, e.g. 'USD', 'BRL', 'EUR'",
+  "date": "YYYY-MM-DD format",
+  "type": "expense" or "income",
+  "description": "brief purchase description in English, max 255 chars",
+  "categoryName": "e.g. Food & Dining, Shopping, Transportation, Entertainment, Healthcare, Utilities, Housing, Education, Travel, Other",
+  "subcategoryName": "optional subcategory or null",
+  "notes": "any relevant details or null",
+  "confidence": "high", "medium", or "low"
+}
+
+Rules:
+- Return ONLY the JSON object, no markdown fences, no explanation.
+- "type" is almost always "expense" unless this is a refund or income receipt.
+- "currency" must be derived from the receipt locale/symbol; default to "USD" if unclear.
+- "date" must be the transaction date on the receipt, not today's date.
+- "amount" is the grand total including tax, as a plain number string.`;
+
+export async function getReceiptProvider(): Promise<ReceiptProvider> {
+  switch (env.RECEIPT_PROVIDER) {
+    case 'openai': {
+      const { OpenAIReceiptProvider } = await import('./receipt-providers/openai.js');
+      return new OpenAIReceiptProvider();
+    }
+    case 'qwen': {
+      const { QwenReceiptProvider } = await import('./receipt-providers/qwen.js');
+      return new QwenReceiptProvider();
+    }
+    case 'anthropic':
+    default: {
+      const { AnthropicReceiptProvider } = await import('./receipt-providers/anthropic.js');
+      return new AnthropicReceiptProvider();
+    }
+  }
+}

--- a/backend/src/services/receiptScanner.ts
+++ b/backend/src/services/receiptScanner.ts
@@ -27,6 +27,12 @@ Rules:
 - "date" must be the transaction date on the receipt, not today's date.
 - "amount" is the grand total including tax, as a plain number string.`;
 
+export function parseReceiptJson(text: string): unknown {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return JSON.parse(fenced ? fenced[1] : trimmed);
+}
+
 export async function getReceiptProvider(): Promise<ReceiptProvider> {
   switch (env.RECEIPT_PROVIDER) {
     case 'openai': {

--- a/frontend/src/components/layout/AddTransactionFAB.tsx
+++ b/frontend/src/components/layout/AddTransactionFAB.tsx
@@ -21,7 +21,7 @@ export function AddTransactionFAB() {
             size="icon"
             variant="secondary"
             className="rounded-full shadow-md size-11"
-            aria-label="Scan receipt"
+            aria-label={t('receiptScanner.scanReceiptAriaLabel')}
           >
             <Camera className="size-4" />
           </Button>

--- a/frontend/src/components/layout/AddTransactionFAB.tsx
+++ b/frontend/src/components/layout/AddTransactionFAB.tsx
@@ -1,20 +1,38 @@
-import { Plus } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, Camera } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useTransactionForm } from '@/providers/TransactionFormProvider';
+import { ReceiptScanner } from '@/components/transactions/ReceiptScanner';
 
 export function AddTransactionFAB() {
   const { t } = useTranslation();
   const { openForm } = useTransactionForm();
+  const [scannerOpen, setScannerOpen] = useState(false);
 
   return (
-    <Button
-      onClick={openForm}
-      size="lg"
-      className="fixed bottom-24 right-6 rounded-full shadow-lg lg:bottom-6"
-      aria-label={t('transactions.addTransaction')}
-    >
-      <Plus className="size-5" />
-    </Button>
+    <>
+      <div className="fixed bottom-24 right-6 flex flex-col items-end gap-2 lg:bottom-6">
+        <Button
+          onClick={() => setScannerOpen(true)}
+          size="icon"
+          variant="secondary"
+          className="rounded-full shadow-md size-11"
+          aria-label="Scan receipt"
+        >
+          <Camera className="size-4" />
+        </Button>
+        <Button
+          onClick={openForm}
+          size="lg"
+          className="rounded-full shadow-lg"
+          aria-label={t('transactions.addTransaction')}
+        >
+          <Plus className="size-5" />
+        </Button>
+      </div>
+
+      <ReceiptScanner open={scannerOpen} onOpenChange={setScannerOpen} />
+    </>
   );
 }

--- a/frontend/src/components/layout/AddTransactionFAB.tsx
+++ b/frontend/src/components/layout/AddTransactionFAB.tsx
@@ -4,24 +4,28 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useTransactionForm } from '@/providers/TransactionFormProvider';
 import { ReceiptScanner } from '@/components/transactions/ReceiptScanner';
+import { useAuth } from '@/lib/auth';
 
 export function AddTransactionFAB() {
   const { t } = useTranslation();
   const { openForm } = useTransactionForm();
+  const { featureFlags } = useAuth();
   const [scannerOpen, setScannerOpen] = useState(false);
 
   return (
     <>
       <div className="fixed bottom-24 right-6 flex flex-col items-end gap-2 lg:bottom-6">
-        <Button
-          onClick={() => setScannerOpen(true)}
-          size="icon"
-          variant="secondary"
-          className="rounded-full shadow-md size-11"
-          aria-label="Scan receipt"
-        >
-          <Camera className="size-4" />
-        </Button>
+        {featureFlags.receiptScanning && (
+          <Button
+            onClick={() => setScannerOpen(true)}
+            size="icon"
+            variant="secondary"
+            className="rounded-full shadow-md size-11"
+            aria-label="Scan receipt"
+          >
+            <Camera className="size-4" />
+          </Button>
+        )}
         <Button
           onClick={openForm}
           size="lg"
@@ -32,7 +36,9 @@ export function AddTransactionFAB() {
         </Button>
       </div>
 
-      <ReceiptScanner open={scannerOpen} onOpenChange={setScannerOpen} />
+      {featureFlags.receiptScanning && (
+        <ReceiptScanner open={scannerOpen} onOpenChange={setScannerOpen} />
+      )}
     </>
   );
 }

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -9,7 +9,7 @@ import { useTransactionForm } from '@/providers/TransactionFormProvider';
 
 export function AppLayout() {
   const { t } = useTranslation();
-  const { isOpen, closeForm } = useTransactionForm();
+  const { isOpen, prefillData, closeForm } = useTransactionForm();
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -28,7 +28,11 @@ export function AppLayout() {
       </div>
       <BottomNav />
       <AddTransactionFAB />
-      <TransactionForm open={isOpen} onOpenChange={closeForm} />
+      <TransactionForm
+        open={isOpen}
+        onOpenChange={closeForm}
+        prefillData={prefillData ?? undefined}
+      />
     </div>
   );
 }

--- a/frontend/src/components/layout/__tests__/AddTransactionFAB.test.tsx
+++ b/frontend/src/components/layout/__tests__/AddTransactionFAB.test.tsx
@@ -1,45 +1,52 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AddTransactionFAB } from '@/components/layout/AddTransactionFAB';
 import { TransactionFormProvider } from '@/providers/TransactionFormProvider';
 
-describe('AddTransactionFAB', () => {
-  it('renders the add transaction button', () => {
-    render(
-      <TransactionFormProvider>
-        <AddTransactionFAB />
-      </TransactionFormProvider>,
-    );
+const mockFlags = { billing: true, receiptScanning: false };
 
-    const button = screen.getByRole('button', { name: /add transaction|add a transaction/i });
-    expect(button).toBeInTheDocument();
+vi.mock('@/lib/auth', () => ({
+  useAuth: () => ({ featureFlags: mockFlags }),
+}));
+
+vi.mock('@/components/transactions/ReceiptScanner', () => ({
+  ReceiptScanner: () => null,
+}));
+
+function renderFAB() {
+  return render(
+    <TransactionFormProvider>
+      <AddTransactionFAB />
+    </TransactionFormProvider>,
+  );
+}
+
+describe('AddTransactionFAB', () => {
+  beforeEach(() => {
+    mockFlags.receiptScanning = false;
+  });
+
+  it('renders the add transaction button', () => {
+    renderFAB();
+    expect(screen.getByRole('button', { name: /add transaction/i })).toBeInTheDocument();
   });
 
   it('calls openForm when clicked', async () => {
     const user = userEvent.setup();
-
-    render(
-      <TransactionFormProvider>
-        <AddTransactionFAB />
-      </TransactionFormProvider>,
-    );
-
-    const button = screen.getByRole('button', { name: /add transaction|add a transaction/i });
-    await user.click(button);
-
-    // Button should still be visible
-    expect(button).toBeInTheDocument();
+    renderFAB();
+    await user.click(screen.getByRole('button', { name: /add transaction/i }));
+    expect(screen.getByRole('button', { name: /add transaction/i })).toBeInTheDocument();
   });
 
-  it('has correct styling classes for floating position', () => {
-    render(
-      <TransactionFormProvider>
-        <AddTransactionFAB />
-      </TransactionFormProvider>,
-    );
+  it('does not show scan receipt button when receiptScanning flag is off', () => {
+    renderFAB();
+    expect(screen.queryByRole('button', { name: /scan receipt/i })).not.toBeInTheDocument();
+  });
 
-    const button = screen.getByRole('button', { name: /add transaction|add a transaction/i });
-    expect(button).toHaveClass('fixed', 'bottom-24', 'right-6', 'rounded-full', 'shadow-lg');
+  it('shows scan receipt button when receiptScanning flag is on', () => {
+    mockFlags.receiptScanning = true;
+    renderFAB();
+    expect(screen.getByRole('button', { name: /scan receipt/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/transactions/ReceiptScanner.tsx
+++ b/frontend/src/components/transactions/ReceiptScanner.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Camera, Upload, X, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
 import {
   Dialog,
@@ -21,10 +22,10 @@ interface ReceiptScannerProps {
 const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'] as const;
 type AcceptedMimeType = (typeof ACCEPTED_TYPES)[number];
 
-const CONFIDENCE_LABELS: Record<ReceiptScanResult['confidence'], string> = {
-  high: 'High confidence',
-  medium: 'Medium confidence',
-  low: 'Low confidence — please verify',
+const CONFIDENCE_LABEL_KEYS: Record<ReceiptScanResult['confidence'], string> = {
+  high: 'receiptScanner.confidenceHigh',
+  medium: 'receiptScanner.confidenceMedium',
+  low: 'receiptScanner.confidenceLow',
 };
 
 const CONFIDENCE_COLORS: Record<ReceiptScanResult['confidence'], string> = {
@@ -34,6 +35,7 @@ const CONFIDENCE_COLORS: Record<ReceiptScanResult['confidence'], string> = {
 };
 
 export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
+  const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [imageBase64, setImageBase64] = useState<string | null>(null);
@@ -75,8 +77,12 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
 
   async function handleScan() {
     if (!imageBase64) return;
-    const { result } = await scanMutation.mutateAsync({ imageBase64, mimeType });
-    setScanResult(result);
+    try {
+      const { result } = await scanMutation.mutateAsync({ imageBase64, mimeType });
+      setScanResult(result);
+    } catch {
+      // handled by scanMutation.isError / onError toast
+    }
   }
 
   function handleUseData() {
@@ -102,11 +108,9 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Camera className="size-5" />
-            Scan Receipt
+            {t('receiptScanner.title')}
           </DialogTitle>
-          <DialogDescription>
-            Upload a photo of your receipt to automatically fill in transaction details.
-          </DialogDescription>
+          <DialogDescription>{t('receiptScanner.dialogDescription')}</DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
@@ -118,8 +122,8 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
               className="flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-border p-10 text-muted-foreground transition-colors hover:border-primary hover:text-primary"
             >
               <Upload className="size-8" />
-              <span className="text-sm font-medium">Tap to select a receipt image</span>
-              <span className="text-xs">JPEG, PNG, WebP supported</span>
+              <span className="text-sm font-medium">{t('receiptScanner.tapToSelect')}</span>
+              <span className="text-xs">{t('receiptScanner.supportedFormats')}</span>
             </button>
           )}
 
@@ -149,7 +153,7 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
                     if (fileInputRef.current) fileInputRef.current.value = '';
                   }}
                   className="absolute right-2 top-2 rounded-full bg-background/80 p-1 text-foreground shadow"
-                  aria-label="Remove image"
+                  aria-label={t('receiptScanner.removeImage')}
                 >
                   <X className="size-4" />
                 </button>
@@ -168,20 +172,20 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
                 ) : (
                   <AlertCircle className="size-4" />
                 )}
-                {CONFIDENCE_LABELS[scanResult.confidence]}
+                {t(CONFIDENCE_LABEL_KEYS[scanResult.confidence])}
               </div>
               <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5">
-                <dt className="text-muted-foreground">Merchant</dt>
+                <dt className="text-muted-foreground">{t('receiptScanner.merchant')}</dt>
                 <dd className="font-medium">{scanResult.merchant}</dd>
-                <dt className="text-muted-foreground">Amount</dt>
+                <dt className="text-muted-foreground">{t('receiptScanner.amount')}</dt>
                 <dd className="font-medium">
                   {scanResult.amount} {scanResult.currency}
                 </dd>
-                <dt className="text-muted-foreground">Date</dt>
+                <dt className="text-muted-foreground">{t('receiptScanner.date')}</dt>
                 <dd className="font-medium">{scanResult.date}</dd>
-                <dt className="text-muted-foreground">Category</dt>
+                <dt className="text-muted-foreground">{t('receiptScanner.category')}</dt>
                 <dd className="font-medium">{scanResult.categoryName}</dd>
-                <dt className="text-muted-foreground">Description</dt>
+                <dt className="text-muted-foreground">{t('receiptScanner.description')}</dt>
                 <dd className="font-medium col-span-2 mt-0.5">{scanResult.description}</dd>
               </dl>
             </div>
@@ -195,17 +199,17 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
 
         <DialogFooter className="gap-2 sm:gap-0">
           <Button type="button" variant="outline" onClick={handleClose}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           {!scanResult ? (
             <Button type="button" onClick={handleScan} disabled={!imageBase64 || isScanning}>
               {isScanning ? (
                 <>
                   <Loader2 className="mr-2 size-4 animate-spin" />
-                  Scanning...
+                  {t('receiptScanner.scanning')}
                 </>
               ) : (
-                'Scan Receipt'
+                t('receiptScanner.scanReceipt')
               )}
             </Button>
           ) : (
@@ -218,10 +222,10 @@ export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
                   scanMutation.reset();
                 }}
               >
-                Re-scan
+                {t('receiptScanner.rescan')}
               </Button>
               <Button type="button" onClick={handleUseData}>
-                Use this data
+                {t('receiptScanner.useThisData')}
               </Button>
             </>
           )}

--- a/frontend/src/components/transactions/ReceiptScanner.tsx
+++ b/frontend/src/components/transactions/ReceiptScanner.tsx
@@ -1,0 +1,232 @@
+import { useRef, useState } from 'react';
+import { Camera, Upload, X, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useReceiptScan } from '@/hooks/useReceiptScan';
+import { useTransactionForm } from '@/providers/TransactionFormProvider';
+import type { ReceiptScanResult } from '@fin-health/shared';
+
+interface ReceiptScannerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'] as const;
+type AcceptedMimeType = (typeof ACCEPTED_TYPES)[number];
+
+const CONFIDENCE_LABELS: Record<ReceiptScanResult['confidence'], string> = {
+  high: 'High confidence',
+  medium: 'Medium confidence',
+  low: 'Low confidence — please verify',
+};
+
+const CONFIDENCE_COLORS: Record<ReceiptScanResult['confidence'], string> = {
+  high: 'text-green-600',
+  medium: 'text-yellow-600',
+  low: 'text-red-600',
+};
+
+export function ReceiptScanner({ open, onOpenChange }: ReceiptScannerProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [imageBase64, setImageBase64] = useState<string | null>(null);
+  const [mimeType, setMimeType] = useState<AcceptedMimeType>('image/jpeg');
+  const [scanResult, setScanResult] = useState<ReceiptScanResult | null>(null);
+
+  const scanMutation = useReceiptScan();
+  const { openFormWithData } = useTransactionForm();
+
+  function handleClose() {
+    setPreview(null);
+    setImageBase64(null);
+    setScanResult(null);
+    scanMutation.reset();
+    onOpenChange(false);
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const type = file.type as AcceptedMimeType;
+    if (!ACCEPTED_TYPES.includes(type)) return;
+
+    setMimeType(type);
+    setScanResult(null);
+    scanMutation.reset();
+
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const dataUrl = ev.target?.result as string;
+      setPreview(dataUrl);
+      // strip the data:image/...;base64, prefix
+      const base64 = dataUrl.split(',')[1];
+      setImageBase64(base64);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  async function handleScan() {
+    if (!imageBase64) return;
+    const { result } = await scanMutation.mutateAsync({ imageBase64, mimeType });
+    setScanResult(result);
+  }
+
+  function handleUseData() {
+    if (!scanResult) return;
+    openFormWithData({
+      amount: scanResult.amount,
+      currency: scanResult.currency,
+      type: scanResult.type,
+      description: scanResult.description,
+      date: scanResult.date,
+      categoryName: scanResult.categoryName,
+      subcategoryName: scanResult.subcategoryName,
+      notes: scanResult.notes,
+    });
+    handleClose();
+  }
+
+  const isScanning = scanMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Camera className="size-5" />
+            Scan Receipt
+          </DialogTitle>
+          <DialogDescription>
+            Upload a photo of your receipt to automatically fill in transaction details.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          {/* Image picker */}
+          {!preview && (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-border p-10 text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+            >
+              <Upload className="size-8" />
+              <span className="text-sm font-medium">Tap to select a receipt image</span>
+              <span className="text-xs">JPEG, PNG, WebP supported</span>
+            </button>
+          )}
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_TYPES.join(',')}
+            capture="environment"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+
+          {/* Preview */}
+          {preview && (
+            <div className="relative">
+              <img
+                src={preview}
+                alt="Receipt preview"
+                className="max-h-64 w-full rounded-lg object-contain"
+              />
+              {!isScanning && !scanResult && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPreview(null);
+                    setImageBase64(null);
+                    if (fileInputRef.current) fileInputRef.current.value = '';
+                  }}
+                  className="absolute right-2 top-2 rounded-full bg-background/80 p-1 text-foreground shadow"
+                  aria-label="Remove image"
+                >
+                  <X className="size-4" />
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Scan result */}
+          {scanResult && (
+            <div className="rounded-lg border bg-muted/40 p-4 text-sm">
+              <div
+                className={`mb-3 flex items-center gap-1.5 font-medium ${CONFIDENCE_COLORS[scanResult.confidence]}`}
+              >
+                {scanResult.confidence === 'high' ? (
+                  <CheckCircle className="size-4" />
+                ) : (
+                  <AlertCircle className="size-4" />
+                )}
+                {CONFIDENCE_LABELS[scanResult.confidence]}
+              </div>
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+                <dt className="text-muted-foreground">Merchant</dt>
+                <dd className="font-medium">{scanResult.merchant}</dd>
+                <dt className="text-muted-foreground">Amount</dt>
+                <dd className="font-medium">
+                  {scanResult.amount} {scanResult.currency}
+                </dd>
+                <dt className="text-muted-foreground">Date</dt>
+                <dd className="font-medium">{scanResult.date}</dd>
+                <dt className="text-muted-foreground">Category</dt>
+                <dd className="font-medium">{scanResult.categoryName}</dd>
+                <dt className="text-muted-foreground">Description</dt>
+                <dd className="font-medium col-span-2 mt-0.5">{scanResult.description}</dd>
+              </dl>
+            </div>
+          )}
+
+          {/* Error */}
+          {scanMutation.isError && !scanResult && (
+            <p className="text-sm text-destructive">{scanMutation.error.message}</p>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button type="button" variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          {!scanResult ? (
+            <Button type="button" onClick={handleScan} disabled={!imageBase64 || isScanning}>
+              {isScanning ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Scanning...
+                </>
+              ) : (
+                'Scan Receipt'
+              )}
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setScanResult(null);
+                  scanMutation.reset();
+                }}
+              >
+                Re-scan
+              </Button>
+              <Button type="button" onClick={handleUseData}>
+                Use this data
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -31,6 +31,7 @@ import {
   type Transaction,
 } from '@/hooks/useTransactions';
 import { format } from 'date-fns';
+import type { TransactionPrefillData } from '@fin-health/shared';
 
 const transactionSchema = z.object({
   amount: z.coerce.number({ message: 'Amount is required' }).positive('Amount must be positive'),
@@ -47,22 +48,11 @@ const transactionSchema = z.object({
 
 type TransactionFormValues = z.infer<typeof transactionSchema>;
 
-interface PrefillData {
-  amount?: string;
-  currency?: string;
-  type?: 'expense' | 'income';
-  description?: string;
-  date?: string;
-  categoryName?: string;
-  subcategoryName?: string;
-  notes?: string;
-}
-
 interface TransactionFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   transaction?: Transaction;
-  prefillData?: PrefillData;
+  prefillData?: TransactionPrefillData;
   onSuccess?: () => void;
 }
 

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -47,10 +47,22 @@ const transactionSchema = z.object({
 
 type TransactionFormValues = z.infer<typeof transactionSchema>;
 
+interface PrefillData {
+  amount?: string;
+  currency?: string;
+  type?: 'expense' | 'income';
+  description?: string;
+  date?: string;
+  categoryName?: string;
+  subcategoryName?: string;
+  notes?: string;
+}
+
 interface TransactionFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   transaction?: Transaction;
+  prefillData?: PrefillData;
   onSuccess?: () => void;
 }
 
@@ -58,6 +70,7 @@ export function TransactionForm({
   open,
   onOpenChange,
   transaction,
+  prefillData,
   onSuccess,
 }: TransactionFormProps) {
   const { t } = useTranslation();
@@ -104,6 +117,17 @@ export function TransactionForm({
         subcategoryName: transaction.subcategory?.name ?? '',
         notes: transaction.notes ?? '',
       });
+    } else if (open && !transaction && prefillData) {
+      reset({
+        amount: prefillData.amount ? parseFloat(prefillData.amount) : 0,
+        type: prefillData.type ?? 'expense',
+        currency: prefillData.currency ?? (i18n.language.startsWith('pt') ? 'BRL' : 'USD'),
+        description: prefillData.description ?? '',
+        date: prefillData.date ?? format(new Date(), 'yyyy-MM-dd'),
+        categoryName: prefillData.categoryName ?? '',
+        subcategoryName: prefillData.subcategoryName ?? '',
+        notes: prefillData.notes ?? '',
+      });
     } else if (open && !transaction) {
       reset({
         amount: 0,
@@ -116,7 +140,7 @@ export function TransactionForm({
         notes: '',
       });
     }
-  }, [open, transaction, reset]);
+  }, [open, transaction, prefillData, reset]);
 
   const categoryNames = useMemo(() => {
     return categories.filter((c) => !selectedType || c.type === selectedType).map((c) => c.name);

--- a/frontend/src/hooks/useReceiptScan.ts
+++ b/frontend/src/hooks/useReceiptScan.ts
@@ -1,0 +1,14 @@
+import { toast } from 'sonner';
+import { trpc } from '@/lib/trpc';
+
+export function useReceiptScan() {
+  return trpc.receipts.scan.useMutation({
+    onError: (error) => {
+      if (error.data?.code === 'FORBIDDEN') {
+        toast.error('Receipt scanning requires a Pro plan');
+      } else {
+        toast.error(error.message || 'Failed to scan receipt');
+      }
+    },
+  });
+}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -10,7 +10,7 @@ interface User {
   plan: UserPlan;
 }
 
-const DEFAULT_FEATURE_FLAGS: FeatureFlags = { billing: true };
+const DEFAULT_FEATURE_FLAGS: FeatureFlags = { billing: true, receiptScanning: false };
 
 interface AuthContextType {
   user: User | null;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -187,6 +187,26 @@
     "clearFilters": "Clear all",
     "currency": "Currency"
   },
+  "receiptScanner": {
+    "title": "Scan Receipt",
+    "dialogDescription": "Upload a photo of your receipt to automatically fill in transaction details.",
+    "tapToSelect": "Tap to select a receipt image",
+    "supportedFormats": "JPEG, PNG, WebP supported",
+    "removeImage": "Remove image",
+    "confidenceHigh": "High confidence",
+    "confidenceMedium": "Medium confidence",
+    "confidenceLow": "Low confidence — please verify",
+    "merchant": "Merchant",
+    "amount": "Amount",
+    "date": "Date",
+    "category": "Category",
+    "description": "Description",
+    "scanning": "Scanning...",
+    "scanReceipt": "Scan Receipt",
+    "rescan": "Re-scan",
+    "useThisData": "Use this data",
+    "scanReceiptAriaLabel": "Scan receipt"
+  },
   "recurring": {
     "title": "Recurring Transactions",
     "subtitle": "Manage your recurring income and expense templates",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -187,6 +187,26 @@
     "clearFilters": "Limpar todos",
     "currency": "Moeda"
   },
+  "receiptScanner": {
+    "title": "Digitalizar Recibo",
+    "dialogDescription": "Envie uma foto do seu recibo para preencher automaticamente os detalhes da transação.",
+    "tapToSelect": "Toque para selecionar uma imagem do recibo",
+    "supportedFormats": "JPEG, PNG, WebP suportados",
+    "removeImage": "Remover imagem",
+    "confidenceHigh": "Alta confiança",
+    "confidenceMedium": "Confiança média",
+    "confidenceLow": "Baixa confiança — verifique os dados",
+    "merchant": "Estabelecimento",
+    "amount": "Valor",
+    "date": "Data",
+    "category": "Categoria",
+    "description": "Descrição",
+    "scanning": "Digitalizando...",
+    "scanReceipt": "Digitalizar Recibo",
+    "rescan": "Digitalizar novamente",
+    "useThisData": "Usar estes dados",
+    "scanReceiptAriaLabel": "Digitalizar recibo"
+  },
   "recurring": {
     "title": "Transações Recorrentes",
     "subtitle": "Gerencie seus modelos de receitas e despesas recorrentes",

--- a/frontend/src/providers/TransactionFormProvider.tsx
+++ b/frontend/src/providers/TransactionFormProvider.tsx
@@ -1,23 +1,11 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
-import type { ReceiptScanResult } from '@fin-health/shared';
-
-type PrefillData = Pick<
-  ReceiptScanResult,
-  | 'amount'
-  | 'currency'
-  | 'type'
-  | 'description'
-  | 'date'
-  | 'categoryName'
-  | 'subcategoryName'
-  | 'notes'
->;
+import type { TransactionPrefillData } from '@fin-health/shared';
 
 interface TransactionFormContextType {
   isOpen: boolean;
-  prefillData: Partial<PrefillData> | null;
+  prefillData: TransactionPrefillData | null;
   openForm: () => void;
-  openFormWithData: (data: Partial<PrefillData>) => void;
+  openFormWithData: (data: TransactionPrefillData) => void;
   closeForm: () => void;
 }
 
@@ -25,14 +13,14 @@ const TransactionFormContext = createContext<TransactionFormContextType | undefi
 
 export function TransactionFormProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [prefillData, setPrefillData] = useState<Partial<PrefillData> | null>(null);
+  const [prefillData, setPrefillData] = useState<TransactionPrefillData | null>(null);
 
   const openForm = () => {
     setPrefillData(null);
     setIsOpen(true);
   };
 
-  const openFormWithData = (data: Partial<PrefillData>) => {
+  const openFormWithData = (data: TransactionPrefillData) => {
     setPrefillData(data);
     setIsOpen(true);
   };

--- a/frontend/src/providers/TransactionFormProvider.tsx
+++ b/frontend/src/providers/TransactionFormProvider.tsx
@@ -1,8 +1,23 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
+import type { ReceiptScanResult } from '@fin-health/shared';
+
+type PrefillData = Pick<
+  ReceiptScanResult,
+  | 'amount'
+  | 'currency'
+  | 'type'
+  | 'description'
+  | 'date'
+  | 'categoryName'
+  | 'subcategoryName'
+  | 'notes'
+>;
 
 interface TransactionFormContextType {
   isOpen: boolean;
+  prefillData: Partial<PrefillData> | null;
   openForm: () => void;
+  openFormWithData: (data: Partial<PrefillData>) => void;
   closeForm: () => void;
 }
 
@@ -10,12 +25,27 @@ const TransactionFormContext = createContext<TransactionFormContextType | undefi
 
 export function TransactionFormProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [prefillData, setPrefillData] = useState<Partial<PrefillData> | null>(null);
 
-  const openForm = () => setIsOpen(true);
-  const closeForm = () => setIsOpen(false);
+  const openForm = () => {
+    setPrefillData(null);
+    setIsOpen(true);
+  };
+
+  const openFormWithData = (data: Partial<PrefillData>) => {
+    setPrefillData(data);
+    setIsOpen(true);
+  };
+
+  const closeForm = () => {
+    setIsOpen(false);
+    setPrefillData(null);
+  };
 
   return (
-    <TransactionFormContext.Provider value={{ isOpen, openForm, closeForm }}>
+    <TransactionFormContext.Provider
+      value={{ isOpen, prefillData, openForm, openFormWithData, closeForm }}
+    >
       {children}
     </TransactionFormContext.Provider>
   );

--- a/frontend/src/providers/__tests__/TransactionFormProvider.test.tsx
+++ b/frontend/src/providers/__tests__/TransactionFormProvider.test.tsx
@@ -4,12 +4,16 @@ import { describe, it, expect } from 'vitest';
 import { TransactionFormProvider, useTransactionForm } from '@/providers/TransactionFormProvider';
 
 function TestComponent() {
-  const { isOpen, openForm, closeForm } = useTransactionForm();
+  const { isOpen, prefillData, openForm, openFormWithData, closeForm } = useTransactionForm();
 
   return (
     <div>
       <div data-testid="form-status">{isOpen ? 'open' : 'closed'}</div>
+      <div data-testid="prefill-amount">{prefillData?.amount ?? 'none'}</div>
       <button onClick={openForm}>Open Form</button>
+      <button onClick={() => openFormWithData({ amount: '99.50', description: 'Scanned receipt' })}>
+        Open With Data
+      </button>
       <button onClick={closeForm}>Close Form</button>
     </div>
   );
@@ -23,8 +27,8 @@ describe('TransactionFormProvider', () => {
       </TransactionFormProvider>,
     );
 
-    const status = screen.getByTestId('form-status');
-    expect(status).toHaveTextContent('closed');
+    expect(screen.getByTestId('form-status')).toHaveTextContent('closed');
+    expect(screen.getByTestId('prefill-amount')).toHaveTextContent('none');
   });
 
   it('opens the form when openForm is called', async () => {
@@ -36,11 +40,10 @@ describe('TransactionFormProvider', () => {
       </TransactionFormProvider>,
     );
 
-    const openButton = screen.getByRole('button', { name: 'Open Form' });
-    await user.click(openButton);
+    await user.click(screen.getByRole('button', { name: 'Open Form' }));
 
-    const status = screen.getByTestId('form-status');
-    expect(status).toHaveTextContent('open');
+    expect(screen.getByTestId('form-status')).toHaveTextContent('open');
+    expect(screen.getByTestId('prefill-amount')).toHaveTextContent('none');
   });
 
   it('closes the form when closeForm is called', async () => {
@@ -52,14 +55,56 @@ describe('TransactionFormProvider', () => {
       </TransactionFormProvider>,
     );
 
-    const openButton = screen.getByRole('button', { name: 'Open Form' });
-    await user.click(openButton);
+    await user.click(screen.getByRole('button', { name: 'Open Form' }));
+    await user.click(screen.getByRole('button', { name: 'Close Form' }));
 
-    const closeButton = screen.getByRole('button', { name: 'Close Form' });
-    await user.click(closeButton);
+    expect(screen.getByTestId('form-status')).toHaveTextContent('closed');
+  });
 
-    const status = screen.getByTestId('form-status');
-    expect(status).toHaveTextContent('closed');
+  it('opens with prefill data when openFormWithData is called', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TransactionFormProvider>
+        <TestComponent />
+      </TransactionFormProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open With Data' }));
+
+    expect(screen.getByTestId('form-status')).toHaveTextContent('open');
+    expect(screen.getByTestId('prefill-amount')).toHaveTextContent('99.50');
+  });
+
+  it('clears prefill data when closeForm is called', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TransactionFormProvider>
+        <TestComponent />
+      </TransactionFormProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open With Data' }));
+    await user.click(screen.getByRole('button', { name: 'Close Form' }));
+
+    expect(screen.getByTestId('prefill-amount')).toHaveTextContent('none');
+  });
+
+  it('clears prefill data when openForm (manual) is called after openFormWithData', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TransactionFormProvider>
+        <TestComponent />
+      </TransactionFormProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open With Data' }));
+    await user.click(screen.getByRole('button', { name: 'Close Form' }));
+    await user.click(screen.getByRole('button', { name: 'Open Form' }));
+
+    expect(screen.getByTestId('prefill-amount')).toHaveTextContent('none');
   });
 
   it('throws error when useTransactionForm is used outside provider', () => {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -62,6 +62,7 @@
     "expo-file-system": "~56.0.7",
     "expo-font": "~56.0.5",
     "expo-haptics": "~56.0.3",
+    "expo-image-picker": "^56.0.16",
     "expo-keep-awake": "~56.0.3",
     "expo-linear-gradient": "~56.0.4",
     "expo-modules-autolinking": "~56.0.0",
@@ -95,8 +96,8 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "29.5.14",
     "jest": "^29.7.0",
-    "oxlint": "latest",
     "jest-expo": "~56.0.4",
+    "oxlint": "latest",
     "prettier": "^3.8.1",
     "typescript": "~6.0.3"
   }

--- a/mobile/src/components/AddTransactionSheet.tsx
+++ b/mobile/src/components/AddTransactionSheet.tsx
@@ -29,13 +29,25 @@ import { BorderRadius, FontSize, Spacing } from '../constants/theme';
 import Toast from 'react-native-toast-message';
 import type { Transaction, Category } from '@fin-health/shared/types';
 
+interface PrefillData {
+  amount?: string;
+  currency?: string;
+  type?: 'expense' | 'income';
+  description?: string;
+  date?: string;
+  categoryName?: string;
+  subcategoryName?: string;
+  notes?: string;
+}
+
 interface Props {
   visible: boolean;
   onClose: () => void;
   transaction?: Transaction | null;
+  prefillData?: PrefillData | null;
 }
 
-export default function AddTransactionSheet({ visible, onClose, transaction }: Props) {
+export default function AddTransactionSheet({ visible, onClose, transaction, prefillData }: Props) {
   const { colors } = useTheme();
   const queryClient = useQueryClient();
   const isEditing = !!transaction;
@@ -89,6 +101,17 @@ export default function AddTransactionSheet({ visible, onClose, transaction }: P
         subcategoryName: transaction.subcategory?.name ?? '',
         notes: transaction.notes ?? '',
       });
+    } else if (!transaction && visible && prefillData) {
+      reset({
+        amount: prefillData.amount ? parseFloat(prefillData.amount) : 0,
+        type: prefillData.type ?? 'expense',
+        currency: prefillData.currency ?? (i18n.language.startsWith('pt') ? 'BRL' : 'USD'),
+        description: prefillData.description ?? '',
+        date: prefillData.date ?? format(new Date(), 'yyyy-MM-dd'),
+        categoryName: prefillData.categoryName ?? '',
+        subcategoryName: prefillData.subcategoryName ?? '',
+        notes: prefillData.notes ?? '',
+      });
     } else if (!transaction && visible) {
       reset({
         amount: 0,
@@ -101,7 +124,7 @@ export default function AddTransactionSheet({ visible, onClose, transaction }: P
         notes: '',
       });
     }
-  }, [transaction, visible, reset]);
+  }, [transaction, visible, prefillData, reset]);
 
   const mutation = useMutation({
     mutationFn: async (data: any) => {

--- a/mobile/src/components/AddTransactionSheet.tsx
+++ b/mobile/src/components/AddTransactionSheet.tsx
@@ -28,23 +28,13 @@ import SegmentedControl from './SegmentedControl';
 import { BorderRadius, FontSize, Spacing } from '../constants/theme';
 import Toast from 'react-native-toast-message';
 import type { Transaction, Category } from '@fin-health/shared/types';
-
-interface PrefillData {
-  amount?: string;
-  currency?: string;
-  type?: 'expense' | 'income';
-  description?: string;
-  date?: string;
-  categoryName?: string;
-  subcategoryName?: string;
-  notes?: string;
-}
+import type { TransactionPrefillData } from '@fin-health/shared';
 
 interface Props {
   visible: boolean;
   onClose: () => void;
   transaction?: Transaction | null;
-  prefillData?: PrefillData | null;
+  prefillData?: TransactionPrefillData | null;
 }
 
 export default function AddTransactionSheet({ visible, onClose, transaction, prefillData }: Props) {

--- a/mobile/src/components/ReceiptScannerSheet.tsx
+++ b/mobile/src/components/ReceiptScannerSheet.tsx
@@ -6,23 +6,12 @@ import { useTheme } from '../contexts/ThemeContext';
 import { trpcClient } from '../lib/trpc';
 import { BorderRadius, FontSize, Spacing } from '../constants/theme';
 import Button from './Button';
-import type { ReceiptScanResult } from '@fin-health/shared';
-
-interface PrefillData {
-  amount?: string;
-  currency?: string;
-  type?: 'expense' | 'income';
-  description?: string;
-  date?: string;
-  categoryName?: string;
-  subcategoryName?: string;
-  notes?: string;
-}
+import type { ReceiptScanResult, TransactionPrefillData } from '@fin-health/shared';
 
 interface Props {
   visible: boolean;
   onClose: () => void;
-  onScanComplete: (data: PrefillData) => void;
+  onScanComplete: (data: TransactionPrefillData) => void;
 }
 
 const CONFIDENCE_COLORS = {
@@ -31,11 +20,14 @@ const CONFIDENCE_COLORS = {
   low: '#dc2626',
 };
 
+const ACCEPTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+type AcceptedMimeType = (typeof ACCEPTED_MIME_TYPES)[number];
+
 export default function ReceiptScannerSheet({ visible, onClose, onScanComplete }: Props) {
   const { colors } = useTheme();
   const [imageUri, setImageUri] = useState<string | null>(null);
   const [imageBase64, setImageBase64] = useState<string | null>(null);
-  const [mimeType, setMimeType] = useState<'image/jpeg' | 'image/png' | 'image/webp'>('image/jpeg');
+  const [mimeType, setMimeType] = useState<AcceptedMimeType>('image/jpeg');
   const [scanResult, setScanResult] = useState<ReceiptScanResult | null>(null);
   const [isScanning, setIsScanning] = useState(false);
 
@@ -63,8 +55,11 @@ export default function ReceiptScannerSheet({ visible, onClose, onScanComplete }
       const asset = result.assets[0];
       setImageUri(asset.uri);
       setImageBase64(asset.base64 ?? null);
-      const type = asset.mimeType as typeof mimeType;
-      setMimeType(type && type.startsWith('image/') ? type : 'image/jpeg');
+      setMimeType(
+        ACCEPTED_MIME_TYPES.includes(asset.mimeType as AcceptedMimeType)
+          ? (asset.mimeType as AcceptedMimeType)
+          : 'image/jpeg',
+      );
       setScanResult(null);
     }
   }

--- a/mobile/src/components/ReceiptScannerSheet.tsx
+++ b/mobile/src/components/ReceiptScannerSheet.tsx
@@ -1,0 +1,393 @@
+import React, { useState } from 'react';
+import { View, Text, Modal, TouchableOpacity, Image, StyleSheet, Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { Camera, Upload, CheckCircle, AlertCircle, X } from 'lucide-react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import { trpcClient } from '../lib/trpc';
+import { BorderRadius, FontSize, Spacing } from '../constants/theme';
+import Button from './Button';
+import type { ReceiptScanResult } from '@fin-health/shared';
+
+interface PrefillData {
+  amount?: string;
+  currency?: string;
+  type?: 'expense' | 'income';
+  description?: string;
+  date?: string;
+  categoryName?: string;
+  subcategoryName?: string;
+  notes?: string;
+}
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  onScanComplete: (data: PrefillData) => void;
+}
+
+const CONFIDENCE_COLORS = {
+  high: '#16a34a',
+  medium: '#d97706',
+  low: '#dc2626',
+};
+
+export default function ReceiptScannerSheet({ visible, onClose, onScanComplete }: Props) {
+  const { colors } = useTheme();
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [imageBase64, setImageBase64] = useState<string | null>(null);
+  const [mimeType, setMimeType] = useState<'image/jpeg' | 'image/png' | 'image/webp'>('image/jpeg');
+  const [scanResult, setScanResult] = useState<ReceiptScanResult | null>(null);
+  const [isScanning, setIsScanning] = useState(false);
+
+  function handleClose() {
+    setImageUri(null);
+    setImageBase64(null);
+    setScanResult(null);
+    onClose();
+  }
+
+  async function pickImage() {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permission required', 'Please allow access to your photo library.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      base64: true,
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets[0]) {
+      const asset = result.assets[0];
+      setImageUri(asset.uri);
+      setImageBase64(asset.base64 ?? null);
+      const type = asset.mimeType as typeof mimeType;
+      setMimeType(type && type.startsWith('image/') ? type : 'image/jpeg');
+      setScanResult(null);
+    }
+  }
+
+  async function takePhoto() {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permission required', 'Please allow camera access.');
+      return;
+    }
+
+    const result = await ImagePicker.launchCameraAsync({
+      base64: true,
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets[0]) {
+      const asset = result.assets[0];
+      setImageUri(asset.uri);
+      setImageBase64(asset.base64 ?? null);
+      setMimeType('image/jpeg');
+      setScanResult(null);
+    }
+  }
+
+  async function handleScan() {
+    if (!imageBase64) return;
+    setIsScanning(true);
+    try {
+      const { result } = await trpcClient.receipts.scan.mutate({ imageBase64, mimeType });
+      setScanResult(result);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to scan receipt';
+      Alert.alert('Scan failed', msg);
+    } finally {
+      setIsScanning(false);
+    }
+  }
+
+  function handleUseData() {
+    if (!scanResult) return;
+    onScanComplete({
+      amount: scanResult.amount,
+      currency: scanResult.currency,
+      type: scanResult.type,
+      description: scanResult.description,
+      date: scanResult.date,
+      categoryName: scanResult.categoryName,
+      subcategoryName: scanResult.subcategoryName,
+      notes: scanResult.notes,
+    });
+    handleClose();
+  }
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={styles.overlay}>
+        <View style={[styles.sheet, { backgroundColor: colors.card }]}>
+          <View style={[styles.handle, { backgroundColor: colors.border }]} />
+
+          <View style={styles.header}>
+            <View style={styles.headerLeft}>
+              <Camera size={20} color={colors.primary} />
+              <Text style={[styles.title, { color: colors.text }]}>Scan Receipt</Text>
+            </View>
+            <TouchableOpacity onPress={handleClose}>
+              <X size={24} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            Take a photo or upload a receipt to auto-fill transaction details.
+          </Text>
+
+          {/* Image preview or picker */}
+          {imageUri ? (
+            <View style={styles.previewContainer}>
+              <Image source={{ uri: imageUri }} style={styles.preview} resizeMode="contain" />
+              {!isScanning && !scanResult && (
+                <TouchableOpacity
+                  style={[styles.removeBtn, { backgroundColor: colors.card }]}
+                  onPress={() => {
+                    setImageUri(null);
+                    setImageBase64(null);
+                  }}
+                >
+                  <X size={16} color={colors.text} />
+                </TouchableOpacity>
+              )}
+            </View>
+          ) : (
+            <View style={styles.pickerRow}>
+              <TouchableOpacity
+                style={[
+                  styles.pickerBtn,
+                  { backgroundColor: colors.inputBg, borderColor: colors.border },
+                ]}
+                onPress={takePhoto}
+              >
+                <Camera size={24} color={colors.primary} />
+                <Text style={[styles.pickerLabel, { color: colors.text }]}>Camera</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.pickerBtn,
+                  { backgroundColor: colors.inputBg, borderColor: colors.border },
+                ]}
+                onPress={pickImage}
+              >
+                <Upload size={24} color={colors.primary} />
+                <Text style={[styles.pickerLabel, { color: colors.text }]}>Gallery</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* Scan result */}
+          {scanResult && (
+            <View
+              style={[
+                styles.resultCard,
+                { backgroundColor: colors.inputBg, borderColor: colors.border },
+              ]}
+            >
+              <View style={styles.confidenceRow}>
+                {scanResult.confidence === 'high' ? (
+                  <CheckCircle size={16} color={CONFIDENCE_COLORS.high} />
+                ) : (
+                  <AlertCircle size={16} color={CONFIDENCE_COLORS[scanResult.confidence]} />
+                )}
+                <Text
+                  style={[
+                    styles.confidenceText,
+                    { color: CONFIDENCE_COLORS[scanResult.confidence] },
+                  ]}
+                >
+                  {scanResult.confidence === 'high'
+                    ? 'High confidence'
+                    : scanResult.confidence === 'medium'
+                      ? 'Medium confidence'
+                      : 'Low confidence — please verify'}
+                </Text>
+              </View>
+              <ResultRow label="Merchant" value={scanResult.merchant} colors={colors} />
+              <ResultRow
+                label="Amount"
+                value={`${scanResult.amount} ${scanResult.currency}`}
+                colors={colors}
+              />
+              <ResultRow label="Date" value={scanResult.date} colors={colors} />
+              <ResultRow label="Category" value={scanResult.categoryName} colors={colors} />
+              <ResultRow label="Description" value={scanResult.description} colors={colors} />
+            </View>
+          )}
+
+          {/* Actions */}
+          <View style={styles.actions}>
+            {!scanResult ? (
+              <>
+                <Button
+                  title="Cancel"
+                  variant="outline"
+                  onPress={handleClose}
+                  style={styles.actionBtn}
+                />
+                <Button
+                  title={isScanning ? 'Scanning...' : 'Scan Receipt'}
+                  onPress={handleScan}
+                  disabled={!imageBase64 || isScanning}
+                  loading={isScanning}
+                  style={styles.actionBtn}
+                />
+              </>
+            ) : (
+              <>
+                <Button
+                  title="Re-scan"
+                  variant="outline"
+                  onPress={() => setScanResult(null)}
+                  style={styles.actionBtn}
+                />
+                <Button title="Use this data" onPress={handleUseData} style={styles.actionBtn} />
+              </>
+            )}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function ResultRow({
+  label,
+  value,
+  colors,
+}: {
+  label: string;
+  value: string;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  return (
+    <View style={styles.resultRow}>
+      <Text style={[styles.resultLabel, { color: colors.textSecondary }]}>{label}</Text>
+      <Text style={[styles.resultValue, { color: colors.text }]}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  sheet: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    maxHeight: '90%',
+    paddingTop: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.xl,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginBottom: Spacing.md,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  title: {
+    fontSize: FontSize.sectionHeader,
+    fontWeight: '600',
+  },
+  subtitle: {
+    fontSize: FontSize.caption,
+    marginBottom: Spacing.lg,
+  },
+  pickerRow: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+    marginBottom: Spacing.lg,
+  },
+  pickerBtn: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.xl,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+  },
+  pickerLabel: {
+    fontSize: FontSize.label,
+    fontWeight: '500',
+  },
+  previewContainer: {
+    position: 'relative',
+    marginBottom: Spacing.lg,
+  },
+  preview: {
+    width: '100%',
+    height: 200,
+    borderRadius: BorderRadius.md,
+  },
+  removeBtn: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    borderRadius: 12,
+    padding: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  resultCard: {
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    padding: Spacing.md,
+    marginBottom: Spacing.lg,
+    gap: Spacing.sm,
+  },
+  confidenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    marginBottom: Spacing.xs,
+  },
+  confidenceText: {
+    fontSize: FontSize.caption,
+    fontWeight: '600',
+  },
+  resultRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: Spacing.md,
+  },
+  resultLabel: {
+    fontSize: FontSize.caption,
+    flex: 1,
+  },
+  resultValue: {
+    fontSize: FontSize.caption,
+    fontWeight: '500',
+    flex: 2,
+    textAlign: 'right',
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+  },
+  actionBtn: {
+    flex: 1,
+  },
+});

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ interface User {
   plan: UserPlan;
 }
 
-const DEFAULT_FEATURE_FLAGS: FeatureFlags = { billing: true };
+const DEFAULT_FEATURE_FLAGS: FeatureFlags = { billing: true, receiptScanning: false };
 
 interface AuthContextValue {
   user: User | null;

--- a/mobile/src/navigation/MainTabNavigator.tsx
+++ b/mobile/src/navigation/MainTabNavigator.tsx
@@ -15,7 +15,7 @@ import CategoriesScreen from '../screens/CategoriesScreen';
 import ChangePasswordScreen from '../screens/ChangePasswordScreen';
 import AddTransactionSheet from '../components/AddTransactionSheet';
 import ReceiptScannerSheet from '../components/ReceiptScannerSheet';
-import type { ReceiptScanResult } from '@fin-health/shared';
+import type { TransactionPrefillData } from '@fin-health/shared';
 import type {
   MainTabParamList,
   HomeStackParamList,
@@ -130,26 +130,14 @@ function EmptyScreen() {
   return null;
 }
 
-type PrefillData = Pick<
-  ReceiptScanResult,
-  | 'amount'
-  | 'currency'
-  | 'type'
-  | 'description'
-  | 'date'
-  | 'categoryName'
-  | 'subcategoryName'
-  | 'notes'
->;
-
 export function MainTabNavigator() {
   const { colors } = useTheme();
   const { featureFlags } = useAuth();
   const [showAddSheet, setShowAddSheet] = useState(false);
   const [showScanner, setShowScanner] = useState(false);
-  const [prefillData, setPrefillData] = useState<Partial<PrefillData> | null>(null);
+  const [prefillData, setPrefillData] = useState<TransactionPrefillData | null>(null);
 
-  function handleScanComplete(data: Partial<PrefillData>) {
+  function handleScanComplete(data: TransactionPrefillData) {
     setPrefillData(data);
     setShowAddSheet(true);
   }

--- a/mobile/src/navigation/MainTabNavigator.tsx
+++ b/mobile/src/navigation/MainTabNavigator.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Home, ArrowLeftRight, PieChart, Settings, Plus } from 'lucide-react-native';
+import { Home, ArrowLeftRight, PieChart, Settings, Plus, Camera } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
+import { useAuth } from '../contexts/AuthContext';
 import DashboardScreen from '../screens/DashboardScreen';
 import SpendingBreakdownScreen from '../screens/SpendingBreakdownScreen';
 import TransactionsScreen from '../screens/TransactionsScreen';
@@ -13,6 +14,8 @@ import SettingsScreen from '../screens/SettingsScreen';
 import CategoriesScreen from '../screens/CategoriesScreen';
 import ChangePasswordScreen from '../screens/ChangePasswordScreen';
 import AddTransactionSheet from '../components/AddTransactionSheet';
+import ReceiptScannerSheet from '../components/ReceiptScannerSheet';
+import type { ReceiptScanResult } from '@fin-health/shared';
 import type {
   MainTabParamList,
   HomeStackParamList,
@@ -127,9 +130,29 @@ function EmptyScreen() {
   return null;
 }
 
+type PrefillData = Pick<
+  ReceiptScanResult,
+  | 'amount'
+  | 'currency'
+  | 'type'
+  | 'description'
+  | 'date'
+  | 'categoryName'
+  | 'subcategoryName'
+  | 'notes'
+>;
+
 export function MainTabNavigator() {
   const { colors } = useTheme();
+  const { featureFlags } = useAuth();
   const [showAddSheet, setShowAddSheet] = useState(false);
+  const [showScanner, setShowScanner] = useState(false);
+  const [prefillData, setPrefillData] = useState<Partial<PrefillData> | null>(null);
+
+  function handleScanComplete(data: Partial<PrefillData>) {
+    setPrefillData(data);
+    setShowAddSheet(true);
+  }
 
   return (
     <>
@@ -171,15 +194,30 @@ export function MainTabNavigator() {
             tabBarLabel: '',
             tabBarIcon: () => null,
             tabBarButton: (_props) => (
-              <TouchableOpacity
-                style={styles.fabContainer}
-                onPress={() => setShowAddSheet(true)}
-                activeOpacity={0.8}
-              >
-                <View style={[styles.fab, { backgroundColor: colors.primary }]}>
+              <View style={styles.fabContainer}>
+                {featureFlags.receiptScanning && (
+                  <TouchableOpacity
+                    style={[
+                      styles.scanBtn,
+                      { backgroundColor: colors.card, borderColor: colors.border },
+                    ]}
+                    onPress={() => setShowScanner(true)}
+                    activeOpacity={0.8}
+                  >
+                    <Camera size={18} color={colors.primary} />
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity
+                  style={[styles.fab, { backgroundColor: colors.primary }]}
+                  onPress={() => {
+                    setPrefillData(null);
+                    setShowAddSheet(true);
+                  }}
+                  activeOpacity={0.8}
+                >
                   <Plus size={28} color="#ffffff" strokeWidth={2.5} />
-                </View>
-              </TouchableOpacity>
+                </TouchableOpacity>
+              </View>
             ),
           }}
         />
@@ -200,7 +238,21 @@ export function MainTabNavigator() {
           }}
         />
       </Tab.Navigator>
-      <AddTransactionSheet visible={showAddSheet} onClose={() => setShowAddSheet(false)} />
+      <AddTransactionSheet
+        visible={showAddSheet}
+        onClose={() => {
+          setShowAddSheet(false);
+          setPrefillData(null);
+        }}
+        prefillData={prefillData}
+      />
+      {featureFlags.receiptScanning && (
+        <ReceiptScannerSheet
+          visible={showScanner}
+          onClose={() => setShowScanner(false)}
+          onScanComplete={handleScanComplete}
+        />
+      )}
     </>
   );
 }
@@ -211,6 +263,20 @@ const styles = StyleSheet.create({
     top: -20,
     justifyContent: 'center',
     alignItems: 'center',
+    gap: 6,
+  },
+  scanBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.15,
+    shadowRadius: 4,
+    elevation: 3,
   },
   fab: {
     width: 56,

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,6 +227,7 @@
         "expo-file-system": "~56.0.7",
         "expo-font": "~56.0.5",
         "expo-haptics": "~56.0.3",
+        "expo-image-picker": "^56.0.16",
         "expo-keep-awake": "~56.0.3",
         "expo-linear-gradient": "~56.0.4",
         "expo-modules-autolinking": "~56.0.0",
@@ -12165,6 +12166,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "56.0.3",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-56.0.3.tgz",
+      "integrity": "sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "56.0.16",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-56.0.16.tgz",
+      "integrity": "sha512-t7tNtkPsbK4D7kKgd0dNylUVTD2IPNmZIa/MXSzMb+uSm7VyHrHfXt+GVZENFRMi99amBGWBuen5OYESwOp5rw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~56.0.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "name": "@fin-health/backend",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.102.0",
         "@fin-health/shared": "*",
         "@prisma/client": "^6.4.1",
         "@sentry/node": "^10.42.0",
@@ -38,6 +39,7 @@
         "helmet": "^8.0.0",
         "i18next": "^25.8.14",
         "jsonwebtoken": "^9.0.2",
+        "openai": "^6.42.0",
         "pino": "^10.3.1",
         "pino-http": "^11.0.0",
         "stripe": "^20.4.1",
@@ -660,6 +662,27 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -8311,6 +8334,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -12837,6 +12866,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -14752,6 +14787,19 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -16324,6 +16372,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/ora": {
@@ -18710,6 +18776,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -19201,6 +19277,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -9,6 +9,7 @@ export type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'expired';
 
 export interface FeatureFlags {
   billing: boolean;
+  receiptScanning: boolean;
 }
 
 export interface UserPlan {

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -3,3 +3,4 @@ export * from './category';
 export * from './transaction';
 export * from './budget';
 export * from './recurring';
+export * from './receipt';

--- a/packages/shared/src/validators/receipt.ts
+++ b/packages/shared/src/validators/receipt.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const receiptScanResultSchema = z.object({
+  merchant: z.string(),
+  amount: z.string(),
+  currency: z.string().length(3).toUpperCase(),
+  date: z.string(),
+  type: z.enum(['expense', 'income']),
+  description: z.string(),
+  categoryName: z.string(),
+  subcategoryName: z.string().optional(),
+  notes: z.string().optional(),
+  confidence: z.enum(['high', 'medium', 'low']),
+});
+
+export const scanReceiptInputSchema = z.object({
+  imageBase64: z.string().min(1),
+  mimeType: z.enum(['image/jpeg', 'image/png', 'image/gif', 'image/webp']),
+});
+
+export type ReceiptScanResult = z.infer<typeof receiptScanResultSchema>;
+export type ScanReceiptInput = z.infer<typeof scanReceiptInputSchema>;

--- a/packages/shared/src/validators/receipt.ts
+++ b/packages/shared/src/validators/receipt.ts
@@ -2,21 +2,35 @@ import { z } from 'zod';
 
 export const receiptScanResultSchema = z.object({
   merchant: z.string(),
-  amount: z.string(),
+  amount: z.string().regex(/^\d+(\.\d{1,2})?$/),
   currency: z.string().length(3).toUpperCase(),
-  date: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   type: z.enum(['expense', 'income']),
   description: z.string(),
   categoryName: z.string(),
-  subcategoryName: z.string().optional(),
-  notes: z.string().optional(),
+  subcategoryName: z.string().nullish(),
+  notes: z.string().nullish(),
   confidence: z.enum(['high', 'medium', 'low']),
 });
 
 export const scanReceiptInputSchema = z.object({
-  imageBase64: z.string().min(1),
+  imageBase64: z.string().min(1).max(10_000_000),
   mimeType: z.enum(['image/jpeg', 'image/png', 'image/gif', 'image/webp']),
 });
 
 export type ReceiptScanResult = z.infer<typeof receiptScanResultSchema>;
 export type ScanReceiptInput = z.infer<typeof scanReceiptInputSchema>;
+
+export type TransactionPrefillData = Partial<
+  Pick<
+    ReceiptScanResult,
+    | 'amount'
+    | 'currency'
+    | 'type'
+    | 'description'
+    | 'date'
+    | 'categoryName'
+    | 'subcategoryName'
+    | 'notes'
+  >
+>;


### PR DESCRIPTION
## Summary

- **Provider-agnostic backend**: `ReceiptProvider` interface with implementations for Claude Haiku 4.5 (`@anthropic-ai/sdk`), GPT-4o-mini (`openai`), and Qwen2.5-VL via DashScope. Selected at runtime via `RECEIPT_PROVIDER` env var.
- **Feature flag**: `FEATURE_RECEIPT_SCANNING` (default `false`) gates the feature server-side in the tRPC router and client-side in the UI. Added to `FeatureFlags` interface and propagated through `auth.me`/`auth.login`/`auth.signup`.
- **Pro-gated tRPC endpoint**: `receipts.scan` uses `proProcedure`; returns `{ result: ReceiptScanResult }` with merchant, amount, currency, date, type, description, category, confidence.
- **Web frontend**: `ReceiptScanner` dialog with file/camera input, image preview, confidence indicator, and "Use this data" button. `TransactionFormProvider` extended with `openFormWithData()` to prefill the transaction form. Camera FAB shown above the "+" button when flag is on.
- **Mobile**: `ReceiptScannerSheet` (expo-image-picker, camera + gallery), wired into `MainTabNavigator` with a small camera button above the FAB. `AddTransactionSheet` extended with `prefillData` prop.
- **Tests**: Backend integration tests (flag-off, unauth, free user, no API key, provider error, happy path). Frontend unit tests for `TransactionFormProvider` prefill lifecycle and `AddTransactionFAB` flag-conditional rendering.

## New env vars required to enable

```
FEATURE_RECEIPT_SCANNING=true
RECEIPT_PROVIDER=anthropic   # or openai or qwen
ANTHROPIC_API_KEY=...        # if using anthropic
OPENAI_API_KEY=...           # if using openai
DASHSCOPE_API_KEY=...        # if using qwen
```

## Test plan

- [ ] With flag off: no camera button in web or mobile UI; `receipts.scan` returns `FORBIDDEN/RECEIPT_SCANNING_DISABLED`
- [ ] With flag on + Pro user: upload a receipt image → form prefills with parsed data
- [ ] With flag on + free user: `receipts.scan` returns `FORBIDDEN/PRO_REQUIRED`
- [ ] Run `npm test -w frontend` → 100 passing
- [ ] Run `npm test -w backend` (requires DB) for receipts.scan integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)