### PR TITLE
Add multi-currency support to recurring transactions

### DIFF
--- a/backend/prisma/migrations/20260612180000_add_recurring_currency/migration.sql
+++ b/backend/prisma/migrations/20260612180000_add_recurring_currency/migration.sql
@@ -1,0 +1,2 @@
+-- Add currency tracking to RecurringTransaction templates
+ALTER TABLE "RecurringTransaction" ADD COLUMN IF NOT EXISTS "currency" TEXT NOT NULL DEFAULT 'USD';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -158,6 +158,7 @@ model RecurringTransaction {
   endDate     DateTime?
   isActive    Boolean             @default(true)
   notes       String?
+  currency    String              @default("USD")
 
   lastGenerated DateTime?
 

--- a/backend/src/routers/auth.ts
+++ b/backend/src/routers/auth.ts
@@ -211,6 +211,7 @@ export const authRouter = router({
           select: {
             id: true,
             amount: true,
+            currency: true,
             type: true,
             description: true,
             frequency: true,

--- a/backend/src/routers/recurring.test.ts
+++ b/backend/src/routers/recurring.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { callerFor, createTestUser, cleanupUser, TestUser } from '../test/helpers';
+
+describe('Recurring transaction procedures', () => {
+  let user: TestUser;
+
+  beforeAll(async () => {
+    user = await createTestUser();
+  });
+
+  afterAll(async () => {
+    await cleanupUser(user.id);
+  });
+
+  async function createRecurring(overrides: Record<string, unknown> = {}) {
+    const caller = await callerFor(user);
+    return caller.recurring.create({
+      amount: '50',
+      type: 'expense',
+      description: 'Test subscription',
+      frequency: 'monthly',
+      startDate: '2025-01-01',
+      categoryName: 'Food',
+      ...overrides,
+    } as Parameters<typeof caller.recurring.create>[0]);
+  }
+
+  describe('recurring.create', () => {
+    it('defaults currency to USD when not provided', async () => {
+      const result = await createRecurring({ description: 'USD subscription' });
+
+      expect(result.recurringTransaction.currency).toBe('USD');
+    });
+
+    it('persists and returns a non-USD currency', async () => {
+      const result = await createRecurring({
+        description: 'BRL subscription',
+        currency: 'brl',
+      });
+
+      expect(result.recurringTransaction.currency).toBe('BRL');
+
+      const caller = await callerFor(user);
+      const fetched = await caller.recurring.byId({ id: result.recurringTransaction.id });
+      expect(fetched.recurringTransaction.currency).toBe('BRL');
+    });
+  });
+
+  describe('recurring.update', () => {
+    it('updates the currency when provided', async () => {
+      const created = await createRecurring({ description: 'Currency update test' });
+
+      const caller = await callerFor(user);
+      const updated = await caller.recurring.update({
+        id: created.recurringTransaction.id,
+        currency: 'eur',
+      });
+
+      expect(updated.recurringTransaction.currency).toBe('EUR');
+    });
+
+    it('leaves currency unchanged when not provided', async () => {
+      const created = await createRecurring({ description: 'No currency change', currency: 'gbp' });
+
+      const caller = await callerFor(user);
+      const updated = await caller.recurring.update({
+        id: created.recurringTransaction.id,
+        amount: '75',
+      });
+
+      expect(updated.recurringTransaction.currency).toBe('GBP');
+      expect(updated.recurringTransaction.amount).toBe(75);
+    });
+  });
+});

--- a/backend/src/routers/recurring.ts
+++ b/backend/src/routers/recurring.ts
@@ -44,6 +44,7 @@ export const recurringRouter = router({
   create: protectedProcedure.input(createRecurringSchema).mutation(async ({ ctx, input }) => {
     const {
       amount,
+      currency,
       type,
       description,
       frequency,
@@ -64,6 +65,7 @@ export const recurringRouter = router({
     const template = await prisma.recurringTransaction.create({
       data: {
         amount,
+        currency: currency.toUpperCase(),
         type,
         description,
         frequency,
@@ -86,6 +88,7 @@ export const recurringRouter = router({
       const {
         id,
         amount,
+        currency,
         type,
         description,
         frequency,
@@ -104,6 +107,7 @@ export const recurringRouter = router({
 
       const updateData: Record<string, unknown> = {};
       if (amount !== undefined) updateData.amount = amount;
+      if (currency !== undefined) updateData.currency = currency.toUpperCase();
       if (type !== undefined) updateData.type = type;
       if (description !== undefined) updateData.description = description;
       if (frequency !== undefined) updateData.frequency = frequency;

--- a/backend/src/services/recurringGenerator.test.ts
+++ b/backend/src/services/recurringGenerator.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { callerFor, createTestUser, cleanupUser, TestUser } from '../test/helpers';
+import { generateRecurringTransactions } from './recurringGenerator';
+import { __testing } from './exchangeRate';
+import prisma from '../lib/prisma';
+
+describe('generateRecurringTransactions', () => {
+  let user: TestUser;
+
+  beforeAll(async () => {
+    user = await createTestUser();
+  });
+
+  afterAll(async () => {
+    await cleanupUser(user.id);
+  });
+
+  afterEach(() => {
+    __testing.clearCache();
+  });
+
+  async function createRecurring(overrides: Record<string, unknown> = {}) {
+    const caller = await callerFor(user);
+    return caller.recurring.create({
+      amount: '50',
+      type: 'expense',
+      description: 'Test subscription',
+      frequency: 'monthly',
+      startDate: '2025-01-01',
+      categoryName: 'Food',
+      ...overrides,
+    } as Parameters<typeof caller.recurring.create>[0]);
+  }
+
+  it('generates a USD transaction with amountUsd equal to amount and exchangeRate 1', async () => {
+    const created = await createRecurring({
+      description: 'USD generator test',
+      amount: '50',
+      startDate: '2025-01-01',
+    });
+
+    const count = await generateRecurringTransactions(user.id);
+    expect(count).toBeGreaterThan(0);
+
+    const generated = await prisma.transaction.findMany({
+      where: { recurringTransactionId: created.recurringTransaction.id },
+    });
+
+    expect(generated.length).toBeGreaterThan(0);
+    for (const tx of generated) {
+      expect(Number(tx.amount)).toBe(50);
+      expect(Number(tx.amountUsd)).toBe(50);
+      expect(Number(tx.exchangeRate)).toBe(1);
+      expect(tx.currency).toBe('USD');
+    }
+  });
+
+  it('generates a non-USD transaction converted to USD using the template currency', async () => {
+    // Seed the exchange rate cache so toUsd doesn't hit the network.
+    // Cache key format: `CCY-YYYY-MM-DD-slot`
+    const now = new Date();
+    const date = now.toISOString().slice(0, 10);
+    const slot = now.getUTCHours() >= 16 ? '16' : '00';
+    __testing.setCacheEntry(`BRL-${date}-${slot}`, 5);
+
+    const created = await createRecurring({
+      description: 'BRL generator test',
+      amount: '100',
+      currency: 'brl',
+      startDate: '2025-01-01',
+    });
+
+    await generateRecurringTransactions(user.id);
+
+    const generated = await prisma.transaction.findMany({
+      where: { recurringTransactionId: created.recurringTransaction.id },
+    });
+
+    expect(generated.length).toBeGreaterThan(0);
+    for (const tx of generated) {
+      expect(tx.currency).toBe('BRL');
+      expect(Number(tx.amount)).toBe(100);
+      expect(Number(tx.exchangeRate)).toBe(5);
+      expect(Number(tx.amountUsd)).toBeCloseTo(20, 5); // 100 / 5
+    }
+  });
+
+  it('skips a template and does not update lastGenerated when the exchange rate lookup fails', async () => {
+    const failingCurrency = 'ZZZ';
+    const created = await createRecurring({
+      description: 'Failing currency generator test',
+      amount: '100',
+      currency: failingCurrency,
+      startDate: '2025-01-01',
+    });
+
+    // No cache entry seeded and fetch is unavailable/will fail in test env,
+    // so toUsd should throw for this unknown currency.
+    const originalFetch = global.fetch;
+    global.fetch = (async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+
+    try {
+      await generateRecurringTransactions(user.id);
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    const generated = await prisma.transaction.findMany({
+      where: { recurringTransactionId: created.recurringTransaction.id },
+    });
+    expect(generated.length).toBe(0);
+
+    const template = await prisma.recurringTransaction.findUnique({
+      where: { id: created.recurringTransaction.id },
+    });
+    expect(template?.lastGenerated).toBeNull();
+  });
+});

--- a/backend/src/services/recurringGenerator.ts
+++ b/backend/src/services/recurringGenerator.ts
@@ -1,5 +1,7 @@
 import { addWeeks, addMonths, addYears, isBefore, isAfter, startOfDay } from 'date-fns';
 import prisma from '../lib/prisma';
+import { toUsd } from './exchangeRate';
+import { logger } from '../lib/logger';
 
 function getNextDate(current: Date, frequency: string): Date {
   switch (frequency) {
@@ -28,7 +30,7 @@ export async function generateRecurringTransactions(userId: string): Promise<num
 
   const allInserts: Array<{
     amount: (typeof templates)[number]['amount'];
-    amountUsd: (typeof templates)[number]['amount'];
+    amountUsd: number;
     exchangeRate: number;
     currency: string;
     type: (typeof templates)[number]['type'];
@@ -46,6 +48,26 @@ export async function generateRecurringTransactions(userId: string): Promise<num
     // Skip if endDate has passed
     if (template.endDate && isBefore(startOfDay(template.endDate), today)) {
       continue;
+    }
+
+    // Resolve currency conversion once per template (generation-time rate).
+    let amountUsd: number;
+    let exchangeRate: number;
+    if (template.currency === 'USD') {
+      amountUsd = Number(template.amount);
+      exchangeRate = 1;
+    } else {
+      try {
+        const converted = await toUsd(Number(template.amount), template.currency);
+        amountUsd = converted.amountUsd;
+        exchangeRate = converted.exchangeRate;
+      } catch (err) {
+        logger.error(
+          { err, templateId: template.id },
+          'Failed to resolve exchange rate for recurring template; skipping',
+        );
+        continue;
+      }
     }
 
     // Determine start point for generation
@@ -67,9 +89,9 @@ export async function generateRecurringTransactions(userId: string): Promise<num
 
       allInserts.push({
         amount: template.amount,
-        amountUsd: template.amount,
-        exchangeRate: 1,
-        currency: 'USD',
+        amountUsd,
+        exchangeRate,
+        currency: template.currency,
         type: template.type,
         description: template.description,
         date: nextDate,

--- a/frontend/src/components/dashboard/RecentPeaks.tsx
+++ b/frontend/src/components/dashboard/RecentPeaks.tsx
@@ -27,7 +27,7 @@ function SkeletonRow() {
 
 export function RecentPeaks({ transactions, isLoading, className }: RecentPeaksProps) {
   const { t } = useTranslation();
-  const { formatCurrency } = useFormatters();
+  const { formatWithCurrency } = useFormatters();
 
   return (
     <Card className={className}>
@@ -74,7 +74,7 @@ export function RecentPeaks({ transactions, isLoading, className }: RecentPeaksP
                       </p>
                     </div>
                     <span className="shrink-0 text-sm font-bold text-destructive">
-                      -{formatCurrency(tx.amount)}
+                      -{formatWithCurrency(tx.amount, tx.currency ?? 'USD')}
                     </span>
                   </li>
                 );

--- a/frontend/src/components/recurring/RecurringCard.tsx
+++ b/frontend/src/components/recurring/RecurringCard.tsx
@@ -22,7 +22,7 @@ export const RecurringCard = memo(function RecurringCard({
   onDelete,
 }: RecurringCardProps) {
   const { t } = useTranslation();
-  const { formatCurrency } = useFormatters();
+  const { formatWithCurrency } = useFormatters();
   const toggleRecurring = useToggleRecurring();
   const categoryName = transaction.category?.name ?? '';
   const config = getCategoryIcon(
@@ -64,7 +64,7 @@ export const RecurringCard = memo(function RecurringCard({
             isIncome ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
           }`}
         >
-          {formatCurrency(transaction.amount)}
+          {formatWithCurrency(transaction.amount, transaction.currency ?? 'USD')}
         </span>
         <Switch
           checked={transaction.isActive}

--- a/frontend/src/components/recurring/RecurringForm.tsx
+++ b/frontend/src/components/recurring/RecurringForm.tsx
@@ -86,8 +86,7 @@ export function RecurringForm({ open, onOpenChange, editingTransaction }: Recurr
       reset({
         amount: editingTransaction.amount,
         type: editingTransaction.type as 'expense' | 'income',
-        currency:
-          (editingTransaction as any).currency || (i18n.language.startsWith('pt') ? 'BRL' : 'USD'),
+        currency: editingTransaction.currency || (i18n.language.startsWith('pt') ? 'BRL' : 'USD'),
         description: editingTransaction.description,
         frequency: editingTransaction.frequency as 'weekly' | 'biweekly' | 'monthly' | 'yearly',
         startDate: format(new Date(editingTransaction.startDate), 'yyyy-MM-dd'),

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -37,7 +37,7 @@ function groupByDate(transactions: Transaction[]) {
 
 export function TransactionList({ transactions }: TransactionListProps) {
   const { t } = useTranslation();
-  const { formatCurrency } = useFormatters();
+  const { formatWithCurrency } = useFormatters();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -190,7 +190,7 @@ export function TransactionList({ transactions }: TransactionListProps) {
                     }`}
                   >
                     {transaction.type === 'income' ? '+' : '-'}
-                    {formatCurrency(transaction.amount)}
+                    {formatWithCurrency(transaction.amount, transaction.currency ?? 'USD')}
                   </td>
                   <td className="px-4 py-3 text-right">
                     <div className="flex items-center justify-end gap-1">

--- a/frontend/src/hooks/useRecurring.ts
+++ b/frontend/src/hooks/useRecurring.ts
@@ -6,6 +6,7 @@ export type { RecurringTransaction };
 
 export interface CreateRecurringPayload {
   amount: number;
+  currency: string;
   type: string;
   description: string;
   frequency: string;

--- a/mobile/src/components/dashboard/RecentPeaks.tsx
+++ b/mobile/src/components/dashboard/RecentPeaks.tsx
@@ -18,7 +18,7 @@ interface RecentPeaksProps {
 export default function RecentPeaks({ transactions, isLoading }: RecentPeaksProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const { formatCurrency } = useFormatters();
+  const { formatWithCurrency } = useFormatters();
 
   return (
     <Card style={styles.container}>
@@ -58,7 +58,7 @@ export default function RecentPeaks({ transactions, isLoading }: RecentPeaksProp
               </View>
               <View style={styles.right}>
                 <Text style={[styles.amount, { color: colors.expense }]}>
-                  {formatCurrency(tx.amount)}
+                  {formatWithCurrency(tx.amount, tx.currency ?? 'USD')}
                 </Text>
                 <Text style={[styles.date, { color: colors.textSecondary }]}>
                   {format(new Date(tx.date), 'MMM d')}

--- a/mobile/src/hooks/useFormatters.ts
+++ b/mobile/src/hooks/useFormatters.ts
@@ -21,6 +21,8 @@ export function useFormatters() {
 
   return {
     formatCurrency: (amount: number) => _formatCurrency(amount, currency, locale),
+    formatWithCurrency: (amount: number, txCurrency: string) =>
+      _formatCurrency(amount, txCurrency, locale),
     formatAmount: (amount: number, type: string) => _formatAmount(amount, type, currency, locale),
     formatDate: (dateStr: string) => _formatDate(dateStr, locale),
     formatPercent: (value: number, decimals?: number) => _formatPercent(value, decimals, locale),

--- a/mobile/src/hooks/useFormatters.ts
+++ b/mobile/src/hooks/useFormatters.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   formatCurrency as _formatCurrency,
@@ -17,16 +18,24 @@ function defaultCurrency(locale: string): string {
 export function useFormatters() {
   const { i18n } = useTranslation();
   const locale = i18n.language;
-  const currency = defaultCurrency(locale);
 
-  return {
-    formatCurrency: (amount: number) => _formatCurrency(amount, currency, locale),
-    formatWithCurrency: (amount: number, txCurrency: string) =>
-      _formatCurrency(amount, txCurrency, locale),
-    formatAmount: (amount: number, type: string) => _formatAmount(amount, type, currency, locale),
-    formatDate: (dateStr: string) => _formatDate(dateStr, locale),
-    formatPercent: (value: number, decimals?: number) => _formatPercent(value, decimals, locale),
-    getMonthName: (month: number) => _getMonthName(month, locale),
-    getShortMonthName: (month: number) => _getShortMonthName(month, locale),
-  };
+  // Memoized on locale so formatters are referentially stable across renders
+  // and safe to use in useCallback/useMemo dependency arrays.
+  return useMemo(() => {
+    const currency = defaultCurrency(locale);
+    return {
+      /** Display currency for converted aggregates (dashboard, budgets). */
+      currency,
+      formatCurrency: (amount: number) => _formatCurrency(amount, currency, locale),
+      formatWithCurrency: (amount: number, txCurrency: string) =>
+        _formatCurrency(amount, txCurrency, locale),
+      formatAmount: (amount: number, type: string) => _formatAmount(amount, type, currency, locale),
+      formatAmountWithCurrency: (amount: number, type: string, txCurrency: string) =>
+        _formatAmount(amount, type, txCurrency, locale),
+      formatDate: (dateStr: string) => _formatDate(dateStr, locale),
+      formatPercent: (value: number, decimals?: number) => _formatPercent(value, decimals, locale),
+      getMonthName: (month: number) => _getMonthName(month, locale),
+      getShortMonthName: (month: number) => _getShortMonthName(month, locale),
+    };
+  }, [locale]);
 }

--- a/mobile/src/screens/BudgetsScreen.tsx
+++ b/mobile/src/screens/BudgetsScreen.tsx
@@ -37,7 +37,7 @@ import { useRouter } from 'expo-router';
 export default function BudgetsScreen() {
   const router = useRouter();
   const { colors } = useTheme();
-  const { formatCurrency } = useFormatters();
+  const { formatCurrency, currency } = useFormatters();
   const queryClient = useQueryClient();
   const now = new Date();
   const [month, setMonth] = useState(now.getMonth() + 1);
@@ -45,8 +45,8 @@ export default function BudgetsScreen() {
   const [showAdd, setShowAdd] = useState(false);
 
   const budgetsQuery = useQuery({
-    queryKey: ['budgets', month, year],
-    queryFn: () => getBudgets(month, year),
+    queryKey: ['budgets', month, year, currency],
+    queryFn: () => getBudgets(month, year, currency),
   });
 
   const categoriesQuery = useQuery({

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -8,6 +8,7 @@ import { Bell } from 'lucide-react-native';
 import { useTheme } from '../contexts/ThemeContext';
 import { useAuth } from '../contexts/AuthContext';
 import { usePlan } from '../hooks/usePlan';
+import { useFormatters } from '../hooks/useFormatters';
 import {
   getSummary,
   getBreakdown,
@@ -35,6 +36,7 @@ export default function DashboardScreen() {
   const { user } = useAuth();
   const { isPro } = usePlan();
   const { t } = useTranslation();
+  const { currency } = useFormatters();
   const now = new Date();
   const [month, setMonth] = useState(now.getMonth() + 1);
   const [year, setYear] = useState(now.getFullYear());
@@ -44,32 +46,32 @@ export default function DashboardScreen() {
 
   // Queries
   const summaryQuery = useQuery({
-    queryKey: ['dashboard', 'summary', month, year],
-    queryFn: () => getSummary(month, year),
+    queryKey: ['dashboard', 'summary', month, year, currency],
+    queryFn: () => getSummary(month, year, currency),
   });
   const prevSummaryQuery = useQuery({
-    queryKey: ['dashboard', 'summary', prevMonth, prevYear],
-    queryFn: () => getSummary(prevMonth, prevYear),
+    queryKey: ['dashboard', 'summary', prevMonth, prevYear, currency],
+    queryFn: () => getSummary(prevMonth, prevYear, currency),
   });
   const breakdownQuery = useQuery({
-    queryKey: ['dashboard', 'breakdown', month, year],
-    queryFn: () => getBreakdown(month, year),
+    queryKey: ['dashboard', 'breakdown', month, year, currency],
+    queryFn: () => getBreakdown(month, year, currency),
   });
   const trendQuery = useQuery({
-    queryKey: ['dashboard', 'trend'],
-    queryFn: () => getTrend(6),
+    queryKey: ['dashboard', 'trend', currency],
+    queryFn: () => getTrend(6, currency),
   });
   const insightsQuery = useQuery({
-    queryKey: ['dashboard', 'insights', month, year],
-    queryFn: () => getInsights(month, year),
+    queryKey: ['dashboard', 'insights', month, year, currency],
+    queryFn: () => getInsights(month, year, currency),
   });
   const recentPeaksQuery = useQuery({
     queryKey: ['dashboard', 'recentPeaks', month, year],
     queryFn: () => getRecentPeaks(month, year),
   });
   const budgetsQuery = useQuery({
-    queryKey: ['budgets', month, year],
-    queryFn: () => getBudgets(month, year),
+    queryKey: ['budgets', month, year, currency],
+    queryFn: () => getBudgets(month, year, currency),
   });
 
   const summary = summaryQuery.data;

--- a/mobile/src/screens/RecurringScreen.tsx
+++ b/mobile/src/screens/RecurringScreen.tsx
@@ -18,6 +18,7 @@ import { createRecurringSchema } from '@fin-health/shared/validators';
 import { X } from 'lucide-react-native';
 import { format } from 'date-fns';
 import Toast from 'react-native-toast-message';
+import i18n from '../lib/i18n';
 import { useTheme } from '../contexts/ThemeContext';
 import {
   getRecurringTransactions,
@@ -38,7 +39,7 @@ import { FontSize, Spacing } from '../constants/theme';
 
 export default function RecurringScreen() {
   const { colors } = useTheme();
-  const { formatCurrency } = useFormatters();
+  const { formatWithCurrency } = useFormatters();
   const queryClient = useQueryClient();
   const [tab, setTab] = useState(0); // 0 = Active, 1 = Paused
   const [showAdd, setShowAdd] = useState(false);
@@ -121,7 +122,7 @@ export default function RecurringScreen() {
                   </View>
                   <View style={styles.itemRight}>
                     <Text style={[styles.itemAmount, { color: colors.text }]}>
-                      {formatCurrency(item.amount)}
+                      {formatWithCurrency(item.amount, item.currency ?? 'USD')}
                     </Text>
                     <Switch
                       value={item.isActive}
@@ -162,6 +163,7 @@ function AddRecurringModal({ visible, onClose }: { visible: boolean; onClose: ()
     defaultValues: {
       amount: '',
       type: 'expense' as const,
+      currency: i18n.language.startsWith('pt') ? 'BRL' : 'USD',
       description: '',
       frequency: 'monthly' as const,
       startDate: format(new Date(), 'yyyy-MM-dd'),
@@ -241,6 +243,21 @@ function AddRecurringModal({ visible, onClose }: { visible: boolean; onClose: ()
                 onSelect={(i) => setValue('type', i === 0 ? 'expense' : 'income')}
               />
             </View>
+
+            <Controller
+              control={control}
+              name="currency"
+              render={({ field: { onChange, value } }) => (
+                <View style={{ marginBottom: 16 }}>
+                  <Text style={[styles.label, { color: colors.text }]}>Currency</Text>
+                  <SegmentedControl
+                    options={['BRL', 'USD', 'EUR']}
+                    selectedIndex={Math.max(['BRL', 'USD', 'EUR'].indexOf(value ?? 'USD'), 0)}
+                    onSelect={(i) => onChange(['BRL', 'USD', 'EUR'][i])}
+                  />
+                </View>
+              )}
+            />
 
             <View style={{ marginBottom: 16 }}>
               <Text style={[styles.label, { color: colors.text, marginBottom: 8 }]}>Frequency</Text>

--- a/mobile/src/screens/SpendingBreakdownScreen.tsx
+++ b/mobile/src/screens/SpendingBreakdownScreen.tsx
@@ -15,15 +15,15 @@ import { FontSize, Spacing, BorderRadius, CategoryColors } from '../constants/th
 
 export default function SpendingBreakdownScreen() {
   const { colors } = useTheme();
-  const { formatCurrency, formatDate } = useFormatters();
+  const { formatCurrency, formatDate, currency } = useFormatters();
   const now = new Date();
   const [month, setMonth] = useState(now.getMonth() + 1);
   const [year, setYear] = useState(now.getFullYear());
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const query = useQuery({
-    queryKey: ['dashboard', 'category-breakdown', month, year],
-    queryFn: () => getCategoryBreakdown(month, year),
+    queryKey: ['dashboard', 'category-breakdown', month, year, currency],
+    queryFn: () => getCategoryBreakdown(month, year, currency),
   });
 
   const categories = query.data?.categories ?? [];

--- a/mobile/src/screens/TransactionsScreen.tsx
+++ b/mobile/src/screens/TransactionsScreen.tsx
@@ -30,7 +30,7 @@ import type { Transaction, CategoryType } from '@fin-health/shared/types';
 
 export default function TransactionsScreen() {
   const { colors } = useTheme();
-  const { formatAmount } = useFormatters();
+  const { formatAmountWithCurrency } = useFormatters();
   const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
   const [filterType, setFilterType] = useState<CategoryType | ''>('');
@@ -85,16 +85,20 @@ export default function TransactionsScreen() {
   // Group by date
   const grouped = groupByDate(allTransactions);
 
-  function confirmDelete(id: string) {
-    Alert.alert('Delete Transaction', 'Are you sure?', [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Delete',
-        style: 'destructive',
-        onPress: () => deleteMutation.mutate(id),
-      },
-    ]);
-  }
+  const { mutate: deleteTx } = deleteMutation;
+  const confirmDelete = useCallback(
+    (id: string) => {
+      Alert.alert('Delete Transaction', 'Are you sure?', [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => deleteTx(id),
+        },
+      ]);
+    },
+    [deleteTx],
+  );
 
   const renderTransaction = useCallback(
     ({ item }: { item: Transaction }) => {
@@ -130,13 +134,13 @@ export default function TransactionsScreen() {
                 { color: item.type === 'income' ? colors.income : colors.expense },
               ]}
             >
-              {formatAmount(item.amount, item.type)}
+              {formatAmountWithCurrency(item.amount, item.type, item.currency ?? 'USD')}
             </Text>
           </Card>
         </TouchableOpacity>
       );
     },
-    [colors],
+    [colors, formatAmountWithCurrency, confirmDelete],
   );
 
   const typeOptions = ['All', 'Income', 'Expense'];

--- a/mobile/src/services/budgets.ts
+++ b/mobile/src/services/budgets.ts
@@ -1,7 +1,7 @@
 import { trpcClient } from '../lib/trpc';
 
-export async function getBudgets(month: number, year: number) {
-  return trpcClient.budgets.list.query({ month, year });
+export async function getBudgets(month: number, year: number, currency = 'USD') {
+  return trpcClient.budgets.list.query({ month, year, currency });
 }
 
 export async function upsertBudget(body: {

--- a/mobile/src/services/dashboard.ts
+++ b/mobile/src/services/dashboard.ts
@@ -1,24 +1,24 @@
 import { startOfMonth, endOfMonth, format } from 'date-fns';
 import { trpcClient } from '../lib/trpc';
 
-export async function getSummary(month: number, year: number) {
-  return trpcClient.dashboard.summary.query({ month, year });
+export async function getSummary(month: number, year: number, currency = 'USD') {
+  return trpcClient.dashboard.summary.query({ month, year, currency });
 }
 
-export async function getBreakdown(month: number, year: number) {
-  return trpcClient.dashboard.breakdown.query({ month, year });
+export async function getBreakdown(month: number, year: number, currency = 'USD') {
+  return trpcClient.dashboard.breakdown.query({ month, year, currency });
 }
 
-export async function getCategoryBreakdown(month: number, year: number) {
-  return trpcClient.dashboard.categoryBreakdown.query({ month, year });
+export async function getCategoryBreakdown(month: number, year: number, currency = 'USD') {
+  return trpcClient.dashboard.categoryBreakdown.query({ month, year, currency });
 }
 
-export async function getTrend(months = 6) {
-  return trpcClient.dashboard.trend.query({ months });
+export async function getTrend(months = 6, currency = 'USD') {
+  return trpcClient.dashboard.trend.query({ months, currency });
 }
 
-export async function getYearlyOverview(year: number) {
-  return trpcClient.dashboard.yearly.query({ year });
+export async function getYearlyOverview(year: number, currency = 'USD') {
+  return trpcClient.dashboard.yearly.query({ year, currency });
 }
 
 export interface Insight {
@@ -29,8 +29,8 @@ export interface Insight {
   metadata?: Record<string, unknown>;
 }
 
-export async function getInsights(month: number, year: number) {
-  return trpcClient.dashboard.insights.query({ month, year });
+export async function getInsights(month: number, year: number, currency = 'USD') {
+  return trpcClient.dashboard.insights.query({ month, year, currency });
 }
 
 export async function getRecentPeaks(month: number, year: number, limit = 5) {

--- a/mobile/src/services/recurring.ts
+++ b/mobile/src/services/recurring.ts
@@ -6,6 +6,7 @@ export async function getRecurringTransactions() {
 
 export async function createRecurring(body: {
   amount: string;
+  currency?: string;
   type: string;
   description: string;
   frequency: string;
@@ -17,6 +18,7 @@ export async function createRecurring(body: {
 }) {
   const result = await trpcClient.recurring.create.mutate({
     amount: body.amount,
+    currency: body.currency,
     type: body.type as 'expense' | 'income',
     description: body.description,
     frequency: body.frequency as 'weekly' | 'biweekly' | 'monthly' | 'yearly',
@@ -33,6 +35,7 @@ export async function updateRecurring(
   id: string,
   body: Partial<{
     amount: string;
+    currency: string;
     type: string;
     description: string;
     frequency: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -106,6 +106,7 @@ export interface Budget {
 export interface RecurringTransaction {
   id: string;
   amount: number;
+  currency: string;
   type: string;
   description: string;
   frequency: string;

--- a/packages/shared/src/validators/recurring.ts
+++ b/packages/shared/src/validators/recurring.ts
@@ -4,6 +4,7 @@ export const createRecurringSchema = z.object({
   amount: z.string().refine((val) => !isNaN(parseFloat(val)) && parseFloat(val) > 0, {
     message: 'Amount must be a positive number',
   }),
+  currency: z.string().length(3).toUpperCase().default('USD'),
   type: z.enum(['expense', 'income']),
   description: z.string().min(1, 'Description is required').max(255),
   frequency: z.enum(['weekly', 'biweekly', 'monthly', 'yearly']),
@@ -27,6 +28,7 @@ export const updateRecurringSchema = z.object({
       message: 'Amount must be a positive number',
     })
     .optional(),
+  currency: z.string().length(3).toUpperCase().optional(),
   type: z.enum(['expense', 'income']).optional(),
   description: z.string().min(1).max(255).optional(),
   frequency: z.enum(['weekly', 'biweekly', 'monthly', 'yearly']).optional(),


### PR DESCRIPTION
## Summary

Recurring templates previously had no currency — the generator assumed USD for every template, and the UIs offered no way to choose. Templates can now be created and edited in any supported currency; generated transactions are converted to USD at generation time using the live exchange rate.

> **Stacked on #3** — contains only the one feature commit on top of the audit-fix branch. Merge #3 first, then retarget/merge this one.

### Backend
- `currency` column on `RecurringTransaction` (default `USD`) + migration
- `currency` accepted in create/update validators and router (uppercased)
- Generator converts non-USD templates via the exchange-rate service at generation time; USD short-circuits without a network call. If the rate API fails, the template is skipped with `lastGenerated` untouched, so it retries on the next login/refresh instead of failing the batch
- Account data export includes the field

### Frontend
- Currency selector in the recurring form (defaults to BRL for pt locale, matching the transaction form)
- Recurring cards display amounts in the template's currency

### Mobile
- BRL/USD/EUR segmented control in the Add Recurring modal, mirroring the Add Transaction sheet
- Recurring list shows amounts in the template currency
- `formatWithCurrency` added to mobile `useFormatters` (parity with frontend)

## Test plan
- [x] Typecheck clean in all 4 workspaces
- [x] Backend: 111/111 tests passing against local Postgres, including new `recurring.test.ts` and `recurringGenerator.test.ts` covering currency passthrough and conversion/skip behavior
- [x] Shared 88/88, frontend 96/96 passing
- [x] Migration applies cleanly
- Note: 16 mobile dashboard-component test failures exist on the base branch and are unrelated (verified by running the same suites on a clean tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)