### PR TITLE
Frontend audit fixes: auth hardening, i18n sweep, billing-flag gating

### DIFF
--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,9 +1,10 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '@/lib/auth';
 import { Skeleton } from '@/components/ui/skeleton';
 
 export function ProtectedRoute() {
   const { user, isLoading } = useAuth();
+  const location = useLocation();
 
   if (isLoading) {
     return (
@@ -19,7 +20,7 @@ export function ProtectedRoute() {
   }
 
   if (!user) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
   return <Outlet />;

--- a/frontend/src/components/dashboard/EditorialInsightCard.tsx
+++ b/frontend/src/components/dashboard/EditorialInsightCard.tsx
@@ -19,8 +19,10 @@ function getNextMonthName(month: number, year: number): string {
 
 export function EditorialInsightCard({ month, year, className }: EditorialInsightCardProps) {
   const { t } = useTranslation();
-  const { isPro } = usePlan();
+  const { isPro, isDisabled } = usePlan();
   const insights$ = useInsights(month, year, isPro);
+
+  if (isDisabled) return null;
 
   const nextMonthName = getNextMonthName(month, year);
 

--- a/frontend/src/components/dashboard/__tests__/EditorialInsightCard.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/EditorialInsightCard.test.tsx
@@ -20,7 +20,7 @@ describe('EditorialInsightCard', () => {
   });
 
   it('shows locked state with CTA when not pro', () => {
-    mockUsePlan.mockReturnValue({ isPro: false });
+    mockUsePlan.mockReturnValue({ isPro: false, isDisabled: false });
     mockUseInsights.mockReturnValue({ data: undefined, isLoading: false });
 
     render(<EditorialInsightCard month={3} year={2026} />);
@@ -30,7 +30,7 @@ describe('EditorialInsightCard', () => {
   });
 
   it('shows loading skeleton when pro and loading', () => {
-    mockUsePlan.mockReturnValue({ isPro: true });
+    mockUsePlan.mockReturnValue({ isPro: true, isDisabled: false });
     mockUseInsights.mockReturnValue({ data: undefined, isLoading: true });
 
     const { container } = render(<EditorialInsightCard month={3} year={2026} />);
@@ -41,7 +41,7 @@ describe('EditorialInsightCard', () => {
   });
 
   it('shows insight content when pro and data loaded', () => {
-    mockUsePlan.mockReturnValue({ isPro: true });
+    mockUsePlan.mockReturnValue({ isPro: true, isDisabled: false });
     mockUseInsights.mockReturnValue({
       data: [
         {
@@ -59,5 +59,14 @@ describe('EditorialInsightCard', () => {
     expect(screen.getByText('Great month!')).toBeInTheDocument();
     expect(screen.getByText('You are saving more.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /upgrade to pro/i })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when billing is disabled', () => {
+    mockUsePlan.mockReturnValue({ isPro: false, isDisabled: true });
+    mockUseInsights.mockReturnValue({ data: undefined, isLoading: false });
+
+    const { container } = render(<EditorialInsightCard month={3} year={2026} />);
+
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -4,6 +4,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import i18n from '@/lib/i18n';
+import { SUPPORTED_CURRENCIES, localeCurrency } from '@/lib/currency';
 import {
   Dialog,
   DialogContent,
@@ -32,20 +33,16 @@ import {
 } from '@/hooks/useTransactions';
 import { format } from 'date-fns';
 
-const transactionSchema = z.object({
-  amount: z.coerce.number({ message: 'Amount is required' }).positive('Amount must be positive'),
-  type: z.enum(['expense', 'income'], {
-    required_error: 'Type is required',
-  }),
-  currency: z.string().length(3),
-  description: z.string().min(1, 'Description is required'),
-  date: z.string().min(1, 'Date is required'),
-  categoryName: z.string().min(1, 'Category is required'),
-  subcategoryName: z.string().optional(),
-  notes: z.string().optional(),
-});
-
-type TransactionFormValues = z.infer<typeof transactionSchema>;
+interface TransactionFormValues {
+  amount: number;
+  type: 'expense' | 'income';
+  currency: string;
+  description: string;
+  date: string;
+  categoryName: string;
+  subcategoryName?: string;
+  notes?: string;
+}
 
 interface TransactionFormProps {
   open: boolean;
@@ -67,6 +64,29 @@ export function TransactionForm({
 
   const isEditing = !!transaction;
 
+  const transactionSchema = useMemo(
+    () =>
+      z.object({
+        amount: z.coerce
+          .number({ message: t('validation.required', { field: t('transactions.amount') }) })
+          .positive(t('validation.amountPositive')),
+        type: z.enum(['expense', 'income'], {
+          required_error: t('validation.required', { field: t('transactions.type') }),
+        }),
+        currency: z.string().length(3),
+        description: z
+          .string()
+          .min(1, t('validation.required', { field: t('transactions.description') })),
+        date: z.string().min(1, t('validation.required', { field: t('transactions.date') })),
+        categoryName: z
+          .string()
+          .min(1, t('validation.required', { field: t('transactions.categoryLabel') })),
+        subcategoryName: z.string().optional(),
+        notes: z.string().optional(),
+      }),
+    [t],
+  );
+
   const {
     register,
     handleSubmit,
@@ -80,7 +100,7 @@ export function TransactionForm({
     defaultValues: {
       amount: 0,
       type: 'expense',
-      currency: i18n.language.startsWith('pt') ? 'BRL' : 'USD',
+      currency: localeCurrency(i18n.language),
       description: '',
       date: format(new Date(), 'yyyy-MM-dd'),
       categoryName: '',
@@ -97,7 +117,7 @@ export function TransactionForm({
       reset({
         amount: transaction.amount,
         type: transaction.type,
-        currency: transaction.currency || (i18n.language.startsWith('pt') ? 'BRL' : 'USD'),
+        currency: transaction.currency || localeCurrency(i18n.language),
         description: transaction.description,
         date: format(new Date(transaction.date), 'yyyy-MM-dd'),
         categoryName: transaction.category.name,
@@ -108,7 +128,7 @@ export function TransactionForm({
       reset({
         amount: 0,
         type: 'expense',
-        currency: i18n.language.startsWith('pt') ? 'BRL' : 'USD',
+        currency: localeCurrency(i18n.language),
         description: '',
         date: format(new Date(), 'yyyy-MM-dd'),
         categoryName: '',
@@ -188,10 +208,11 @@ export function TransactionForm({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="USD">USD</SelectItem>
-                  <SelectItem value="BRL">BRL</SelectItem>
-                  <SelectItem value="EUR">EUR</SelectItem>
-                  <SelectItem value="GBP">GBP</SelectItem>
+                  {SUPPORTED_CURRENCIES.map((currency) => (
+                    <SelectItem key={currency} value={currency}>
+                      {currency}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/contexts/UserPreferencesContext.tsx
+++ b/frontend/src/contexts/UserPreferencesContext.tsx
@@ -1,11 +1,7 @@
 import { createContext, useContext, useState } from 'react';
+import { localeCurrency } from '@/lib/currency';
 
 const CURRENCY_KEY = 'preferredCurrency';
-
-function localeCurrency(lang: string): string {
-  if (lang.startsWith('pt')) return 'BRL';
-  return 'USD';
-}
 
 function initialCurrency(): string {
   const saved = localStorage.getItem(CURRENCY_KEY);

--- a/frontend/src/hooks/useBudgets.ts
+++ b/frontend/src/hooks/useBudgets.ts
@@ -1,4 +1,5 @@
 import { toast } from 'sonner';
+import i18n from '@/lib/i18n';
 import { trpc } from '@/lib/trpc';
 import { useUserPreferences } from '@/contexts/UserPreferencesContext';
 import type { Budget } from '@fin-health/shared/types';
@@ -17,7 +18,7 @@ export function useUpsertBudget() {
   return trpc.budgets.upsert.useMutation({
     onSuccess: () => {
       utils.budgets.list.invalidate();
-      toast.success('Budget saved successfully');
+      toast.success(i18n.t('toasts.budgetSaved'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -32,9 +33,9 @@ export function useCopyPreviousMonthBudgets() {
     onSuccess: (data) => {
       utils.budgets.list.invalidate();
       if (data.copied > 0) {
-        toast.success(`Copied ${data.copied} budget(s) from last month`);
+        toast.success(i18n.t('toasts.budgetsCopied', { count: data.copied }));
       } else {
-        toast.info('No budgets to copy from last month');
+        toast.info(i18n.t('toasts.budgetsCopyNoResults'));
       }
     },
     onError: (error) => {
@@ -49,7 +50,7 @@ export function useDeleteBudget() {
   return trpc.budgets.delete.useMutation({
     onSuccess: () => {
       utils.budgets.list.invalidate();
-      toast.success('Budget deleted successfully');
+      toast.success(i18n.t('toasts.budgetDeleted'));
     },
     onError: (error) => {
       toast.error(error.message);

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -1,4 +1,5 @@
 import { toast } from 'sonner';
+import i18n from '@/lib/i18n';
 import { trpc } from '@/lib/trpc';
 import type { Category, Subcategory } from '@fin-health/shared/types';
 
@@ -15,7 +16,7 @@ export function useCreateSubcategory() {
   return trpc.categories.createSubcategory.useMutation({
     onSuccess: () => {
       utils.categories.list.invalidate();
-      toast.success('Subcategory created successfully');
+      toast.success(i18n.t('toasts.subcategoryCreated'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -29,7 +30,7 @@ export function useRenameCategory() {
   return trpc.categories.update.useMutation({
     onSuccess: () => {
       utils.categories.list.invalidate();
-      toast.success('Category renamed successfully');
+      toast.success(i18n.t('toasts.categoryRenamed'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -43,7 +44,7 @@ export function useRenameSubcategory() {
   return trpc.categories.renameSubcategory.useMutation({
     onSuccess: () => {
       utils.categories.list.invalidate();
-      toast.success('Subcategory renamed successfully');
+      toast.success(i18n.t('toasts.subcategoryRenamed'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -57,7 +58,7 @@ export function useDeleteCategory() {
   return trpc.categories.delete.useMutation({
     onSuccess: () => {
       utils.categories.list.invalidate();
-      toast.success('Category deleted successfully');
+      toast.success(i18n.t('toasts.categoryDeleted'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -71,7 +72,7 @@ export function useDeleteSubcategory() {
   return trpc.categories.deleteSubcategory.useMutation({
     onSuccess: () => {
       utils.categories.list.invalidate();
-      toast.success('Subcategory deleted successfully');
+      toast.success(i18n.t('toasts.subcategoryDeleted'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -102,7 +103,7 @@ export function useMergeCategory() {
     onSuccess: () => {
       utils.categories.list.invalidate();
       utils.transactions.list.invalidate();
-      toast.success('Categories merged successfully');
+      toast.success(i18n.t('toasts.categoriesMerged'));
     },
     onError: (error) => {
       toast.error(error.message);

--- a/frontend/src/hooks/useRecurring.ts
+++ b/frontend/src/hooks/useRecurring.ts
@@ -1,4 +1,5 @@
 import { toast } from 'sonner';
+import i18n from '@/lib/i18n';
 import { trpc } from '@/lib/trpc';
 import type { RecurringTransaction } from '@fin-health/shared/types';
 
@@ -32,7 +33,7 @@ export function useCreateRecurring() {
   return trpc.recurring.create.useMutation({
     onSuccess: () => {
       utils.recurring.list.invalidate();
-      toast.success('Recurring transaction created');
+      toast.success(i18n.t('toasts.recurringCreated'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -46,7 +47,7 @@ export function useUpdateRecurring() {
   return trpc.recurring.update.useMutation({
     onSuccess: () => {
       utils.recurring.list.invalidate();
-      toast.success('Recurring transaction updated');
+      toast.success(i18n.t('toasts.recurringUpdated'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -60,7 +61,7 @@ export function useDeleteRecurring() {
   return trpc.recurring.delete.useMutation({
     onSuccess: () => {
       utils.recurring.list.invalidate();
-      toast.success('Recurring transaction deleted');
+      toast.success(i18n.t('toasts.recurringDeleted'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -74,7 +75,7 @@ export function useToggleRecurring() {
   return trpc.recurring.toggle.useMutation({
     onSuccess: () => {
       utils.recurring.list.invalidate();
-      toast.success('Recurring transaction toggled');
+      toast.success(i18n.t('toasts.recurringToggled'));
     },
     onError: (error) => {
       toast.error(error.message);

--- a/frontend/src/hooks/useTransactions.ts
+++ b/frontend/src/hooks/useTransactions.ts
@@ -1,4 +1,5 @@
 import { toast } from 'sonner';
+import i18n from '@/lib/i18n';
 import { trpc } from '@/lib/trpc';
 import api, { parseError } from '@/lib/api';
 import type { Transaction, TransactionFilters } from '@fin-health/shared/types';
@@ -42,7 +43,7 @@ export function useCreateTransaction() {
     onSuccess: () => {
       utils.transactions.list.invalidate();
       utils.categories.list.invalidate();
-      toast.success('Transaction created successfully');
+      toast.success(i18n.t('toasts.transactionCreated'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -57,7 +58,7 @@ export function useUpdateTransaction() {
     onSuccess: () => {
       utils.transactions.list.invalidate();
       utils.categories.list.invalidate();
-      toast.success('Transaction updated successfully');
+      toast.success(i18n.t('toasts.transactionUpdated'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -72,7 +73,7 @@ export function useDeleteTransaction() {
     onSuccess: () => {
       utils.transactions.list.invalidate();
       utils.categories.list.invalidate();
-      toast.success('Transaction deleted successfully');
+      toast.success(i18n.t('toasts.transactionDeleted'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -87,7 +88,7 @@ export function useBulkDeleteTransactions() {
     onSuccess: () => {
       utils.transactions.list.invalidate();
       utils.categories.list.invalidate();
-      toast.success('Transactions deleted successfully');
+      toast.success(i18n.t('toasts.transactionsDeleted'));
     },
     onError: (error) => {
       toast.error(error.message);
@@ -118,7 +119,7 @@ export async function exportTransactions(filters: TransactionFilters = {}): Prom
     link.remove();
     window.URL.revokeObjectURL(url);
 
-    toast.success('Transactions exported successfully');
+    toast.success(i18n.t('toasts.transactionsExported'));
   } catch (error) {
     toast.error(parseError(error).message);
   }

--- a/frontend/src/lib/__tests__/auth.test.tsx
+++ b/frontend/src/lib/__tests__/auth.test.tsx
@@ -113,13 +113,13 @@ describe('useAuth', () => {
     expect(result.current.token).toBe('existing-token');
   });
 
-  it('clears token if fetching user fails', async () => {
+  it('clears token if fetching user fails with UNAUTHORIZED', async () => {
     localStorage.setItem('token', 'bad-token');
     mockAuthMeUseQuery.mockReturnValue({
       isSuccess: false,
       isError: true,
       data: undefined,
-      error: new Error('Unauthorized'),
+      error: { data: { code: 'UNAUTHORIZED' } },
       refetch: vi.fn(),
     });
 
@@ -132,6 +132,26 @@ describe('useAuth', () => {
     expect(result.current.user).toBeNull();
     expect(result.current.token).toBeNull();
     expect(localStorage.getItem('token')).toBeNull();
+  });
+
+  it('keeps token if fetching user fails with a non-auth error', async () => {
+    localStorage.setItem('token', 'good-token');
+    mockAuthMeUseQuery.mockReturnValue({
+      isSuccess: false,
+      isError: true,
+      data: undefined,
+      error: new Error('Network request failed'),
+      refetch: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(localStorage.getItem('token')).toBe('good-token');
   });
 
   it('login stores token and sets user', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { env } from '@/lib/env';
+import { refreshTokens } from '@/lib/tokenRefresh';
 
 export { AppError, parseError } from '@fin-health/shared/errors';
 export type { ErrorCode } from '@fin-health/shared/errors';
@@ -34,14 +35,6 @@ api.interceptors.request.use(
 // Response interceptor — silent refresh on 401
 // ---------------------------------------------------------------------------
 
-let isRefreshing = false;
-let refreshSubscribers: Array<(token: string) => void> = [];
-
-function onTokenRefreshed(token: string) {
-  refreshSubscribers.forEach((cb) => cb(token));
-  refreshSubscribers = [];
-}
-
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -60,38 +53,15 @@ api.interceptors.response.use(
 
     originalRequest._retry = true;
 
-    if (isRefreshing) {
-      return new Promise((resolve) => {
-        refreshSubscribers.push((newToken: string) => {
-          originalRequest.headers.Authorization = `Bearer ${newToken}`;
-          resolve(api(originalRequest));
-        });
-      });
-    }
+    const newToken = await refreshTokens();
 
-    isRefreshing = true;
-
-    try {
-      const refreshToken = localStorage.getItem('refreshToken');
-      if (!refreshToken) throw new Error('No refresh token');
-
-      const { data } = await axios.post(`${env.VITE_API_URL}/auth/refresh`, { refreshToken });
-
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('refreshToken', data.refreshToken);
-
-      onTokenRefreshed(data.token);
-
-      originalRequest.headers.Authorization = `Bearer ${data.token}`;
-      return api(originalRequest);
-    } catch {
-      localStorage.removeItem('token');
-      localStorage.removeItem('refreshToken');
+    if (!newToken) {
       onAuthError?.();
       return Promise.reject(error);
-    } finally {
-      isRefreshing = false;
     }
+
+    originalRequest.headers.Authorization = `Bearer ${newToken}`;
+    return api(originalRequest);
   },
 );
 

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -52,13 +52,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (meQuery.data.featureFlags) setFeatureFlags(meQuery.data.featureFlags as FeatureFlags);
       setIsLoading(false);
     } else if (meQuery.isError) {
-      localStorage.removeItem('token');
-      localStorage.removeItem('refreshToken');
-      setHasToken(false);
-      setUser(null);
+      // Only log out on UNAUTHORIZED/FORBIDDEN errors; network errors don't touch localStorage
+      const errorCode = meQuery.error?.data?.code;
+      if (errorCode === 'UNAUTHORIZED' || errorCode === 'FORBIDDEN') {
+        localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
+        setHasToken(false);
+        setUser(null);
+      }
       setIsLoading(false);
     }
-  }, [hasToken, meQuery.isSuccess, meQuery.isError, meQuery.data]);
+  }, [hasToken, meQuery.isSuccess, meQuery.isError, meQuery.data, meQuery.error]);
 
   // Register the refresh-failure handler so 401s go through React Router
   useEffect(() => {
@@ -68,6 +72,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       navigate('/login', { replace: true });
     });
     return () => setTRPCAuthFailure(null);
+  }, [navigate]);
+
+  // Listen for cross-tab logout via storage event
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === 'token' && event.newValue === null) {
+        setHasToken(false);
+        setUser(null);
+        navigate('/login', { replace: true });
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
   }, [navigate]);
 
   const login = useCallback(

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -1,0 +1,5 @@
+export const SUPPORTED_CURRENCIES = ['USD', 'BRL', 'EUR', 'GBP'] as const;
+
+export function localeCurrency(lang: string): string {
+  return lang.startsWith('pt') ? 'BRL' : 'USD';
+}

--- a/frontend/src/lib/tokenRefresh.ts
+++ b/frontend/src/lib/tokenRefresh.ts
@@ -1,0 +1,47 @@
+import { env } from '@/lib/env';
+
+let currentRefreshPromise: Promise<string | null> | null = null;
+
+export function refreshTokens(): Promise<string | null> {
+  // If a refresh is already in flight, return the same promise
+  if (currentRefreshPromise) {
+    return currentRefreshPromise;
+  }
+
+  // Start a new refresh
+  currentRefreshPromise = (async () => {
+    try {
+      const refreshToken = localStorage.getItem('refreshToken');
+      if (!refreshToken) {
+        return null;
+      }
+
+      const response = await fetch(`${env.VITE_API_URL}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      });
+
+      if (!response.ok) {
+        // HTTP error: clear tokens
+        localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
+        return null;
+      }
+
+      const data = await response.json();
+      localStorage.setItem('token', data.token);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      return data.token as string;
+    } catch {
+      // Error: clear tokens
+      localStorage.removeItem('token');
+      localStorage.removeItem('refreshToken');
+      return null;
+    } finally {
+      currentRefreshPromise = null;
+    }
+  })();
+
+  return currentRefreshPromise;
+}

--- a/frontend/src/lib/trpc.ts
+++ b/frontend/src/lib/trpc.ts
@@ -3,6 +3,7 @@ import { httpBatchLink } from '@trpc/client';
 import superjson from 'superjson';
 import type { AppRouter } from '@fin-health/backend/trpc';
 import { env } from '@/lib/env';
+import { refreshTokens } from '@/lib/tokenRefresh';
 
 export const trpc = createTRPCReact<AppRouter>();
 
@@ -11,28 +12,6 @@ let onAuthFailure: (() => void) | null = null;
 
 export function setTRPCAuthFailure(handler: (() => void) | null) {
   onAuthFailure = handler;
-}
-
-let isRefreshing = false;
-let refreshQueue: Array<(token: string | null) => void> = [];
-
-async function doRefresh(): Promise<string | null> {
-  const refreshToken = localStorage.getItem('refreshToken');
-  if (!refreshToken) return null;
-  try {
-    const res = await fetch(`${env.VITE_API_URL}/auth/refresh`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken }),
-    });
-    if (!res.ok) return null;
-    const data = await res.json();
-    localStorage.setItem('token', data.token);
-    localStorage.setItem('refreshToken', data.refreshToken);
-    return data.token as string;
-  } catch {
-    return null;
-  }
 }
 
 async function authenticatedFetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response> {
@@ -53,28 +32,15 @@ async function authenticatedFetch(url: RequestInfo | URL, init?: RequestInit): P
     return response;
   }
 
-  // Queue callers behind a single in-flight refresh
-  if (!isRefreshing) {
-    isRefreshing = true;
-    doRefresh().then((newToken) => {
-      const waiters = refreshQueue;
-      refreshQueue = [];
-      isRefreshing = false;
-      waiters.forEach((cb) => cb(newToken));
-      if (!newToken) {
-        localStorage.removeItem('token');
-        localStorage.removeItem('refreshToken');
-        onAuthFailure?.();
-      }
-    });
+  // Attempt to refresh tokens
+  const newToken = await refreshTokens();
+
+  if (!newToken) {
+    onAuthFailure?.();
+    return response;
   }
 
-  const newToken = await new Promise<string | null>((resolve) => {
-    refreshQueue.push(resolve);
-  });
-
-  if (!newToken) return response;
-
+  // Retry the request with the new token
   const retryHeaders = new Headers(init?.headers);
   retryHeaders.set('Authorization', `Bearer ${newToken}`);
   return fetch(url, { ...init, headers: retryHeaders });

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -352,6 +352,27 @@
     "amountPositive": "Amount must be positive",
     "confirmPassword": "Please confirm your password"
   },
+  "toasts": {
+    "transactionCreated": "Transaction created successfully",
+    "transactionUpdated": "Transaction updated successfully",
+    "transactionDeleted": "Transaction deleted successfully",
+    "transactionsDeleted": "Transactions deleted successfully",
+    "transactionsExported": "Transactions exported successfully",
+    "subcategoryCreated": "Subcategory created successfully",
+    "categoryRenamed": "Category renamed successfully",
+    "subcategoryRenamed": "Subcategory renamed successfully",
+    "categoryDeleted": "Category deleted successfully",
+    "subcategoryDeleted": "Subcategory deleted successfully",
+    "budgetSaved": "Budget saved successfully",
+    "budgetDeleted": "Budget deleted successfully",
+    "budgetsCopied": "Copied {{count}} budget(s) from last month",
+    "budgetsCopyNoResults": "No budgets to copy from last month",
+    "recurringCreated": "Recurring transaction created",
+    "recurringUpdated": "Recurring transaction updated",
+    "recurringDeleted": "Recurring transaction deleted",
+    "recurringToggled": "Recurring transaction toggled",
+    "categoriesMerged": "Categories merged successfully"
+  },
   "plan": {
     "upgradeTitle": "Upgrade to Pro",
     "upgradeDescription": "This feature is available on the Pro plan. Upgrade to unlock insights and more.",

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -352,6 +352,27 @@
     "amountPositive": "O valor deve ser positivo",
     "confirmPassword": "Por favor, confirme sua senha"
   },
+  "toasts": {
+    "transactionCreated": "Transação criada com sucesso",
+    "transactionUpdated": "Transação atualizada com sucesso",
+    "transactionDeleted": "Transação excluída com sucesso",
+    "transactionsDeleted": "Transações excluídas com sucesso",
+    "transactionsExported": "Transações exportadas com sucesso",
+    "subcategoryCreated": "Subcategoria criada com sucesso",
+    "categoryRenamed": "Categoria renomeada com sucesso",
+    "subcategoryRenamed": "Subcategoria renomeada com sucesso",
+    "categoryDeleted": "Categoria excluída com sucesso",
+    "subcategoryDeleted": "Subcategoria excluída com sucesso",
+    "budgetSaved": "Orçamento salvo com sucesso",
+    "budgetDeleted": "Orçamento excluído com sucesso",
+    "budgetsCopied": "{{count}} orçamento(s) copiado(s) do mês passado",
+    "budgetsCopyNoResults": "Nenhum orçamento para copiar do mês passado",
+    "recurringCreated": "Transação recorrente criada",
+    "recurringUpdated": "Transação recorrente atualizada",
+    "recurringDeleted": "Transação recorrente excluída",
+    "recurringToggled": "Transação recorrente alternada",
+    "categoriesMerged": "Categorias mescladas com sucesso"
+  },
   "plan": {
     "upgradeTitle": "Upgrade para Pro",
     "upgradeDescription": "Este recurso está disponível no plano Pro. Faça upgrade para desbloquear insights e mais.",

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -11,9 +11,11 @@ import { RecentPeaks } from '@/components/dashboard/RecentPeaks';
 import { BudgetComplianceTable } from '@/components/dashboard/BudgetComplianceTable';
 import { useSummary, useCategoryBreakdown, useTrend, useRecentPeaks } from '@/hooks/useDashboard';
 import { useBudgets } from '@/hooks/useBudgets';
+import { usePlan } from '@/hooks/usePlan';
 
 export default function Dashboard() {
   const { t } = useTranslation();
+  const { isDisabled } = usePlan();
   const now = new Date();
   const [month, setMonth] = useState(now.getMonth() + 1);
   const [year, setYear] = useState(now.getFullYear());
@@ -28,7 +30,7 @@ export default function Dashboard() {
 
   const categoryBreakdown$ = useCategoryBreakdown(month, year);
   const trend$ = useTrend(6);
-  const { data: budgets } = useBudgets(month, year);
+  const { data: budgets, isError: budgetsError, refetch: refetchBudgets } = useBudgets(month, year);
   const recentPeaks$ = useRecentPeaks(month, year);
 
   // Derive month-over-month net change percentage
@@ -38,7 +40,12 @@ export default function Dashboard() {
   }, [summary$.data, prevSummary$.data]);
 
   const hasError =
-    summary$.isError || categoryBreakdown$.isError || trend$.isError || recentPeaks$.isError;
+    summary$.isError ||
+    categoryBreakdown$.isError ||
+    trend$.isError ||
+    recentPeaks$.isError ||
+    prevSummary$.isError ||
+    budgetsError;
 
   return (
     <div className="space-y-8">
@@ -59,9 +66,11 @@ export default function Dashboard() {
         <QueryError
           onRetry={() => {
             summary$.refetch();
+            prevSummary$.refetch();
             categoryBreakdown$.refetch();
             trend$.refetch();
             recentPeaks$.refetch();
+            refetchBudgets();
           }}
         />
       ) : (
@@ -79,16 +88,18 @@ export default function Dashboard() {
 
           {/* Row 2: Cash Flow Trend + Editorial Insight */}
           <section className="grid grid-cols-12 gap-8">
-            <div className="col-span-12 lg:col-span-8">
+            <div className={`col-span-12 ${isDisabled ? 'lg:col-span-12' : 'lg:col-span-8'}`}>
               {trend$.isLoading ? (
                 <CardSkeleton />
               ) : trend$.data ? (
                 <TrendChart trend={trend$.data} />
               ) : null}
             </div>
-            <div className="col-span-12 lg:col-span-4">
-              <EditorialInsightCard month={month} year={year} />
-            </div>
+            {!isDisabled && (
+              <div className="col-span-12 lg:col-span-4">
+                <EditorialInsightCard month={month} year={year} />
+              </div>
+            )}
           </section>
 
           {/* Row 3: Spending Allocation + Recent Peaks */}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useState, useMemo } from 'react';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -12,19 +12,27 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-const loginSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
-  password: z.string().min(1, 'Password is required'),
-});
-
-type LoginFormData = z.infer<typeof loginSchema>;
+interface LoginFormData {
+  email: string;
+  password: string;
+}
 
 export default function Login() {
   const { t } = useTranslation();
   const { login } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  const loginSchema = useMemo(
+    () =>
+      z.object({
+        email: z.string().email(t('validation.invalidEmail')),
+        password: z.string().min(1, t('validation.required', { field: t('auth.password') })),
+      }),
+    [t],
+  );
 
   const {
     register,
@@ -38,7 +46,8 @@ export default function Login() {
     setIsSubmitting(true);
     try {
       await login(data.email, data.password);
-      navigate('/');
+      const from = (location.state as { from?: { pathname?: string } })?.from?.pathname ?? '/';
+      navigate(from);
     } catch (error: unknown) {
       toast.error(parseError(error).message);
     } finally {
@@ -78,12 +87,7 @@ export default function Login() {
             )}
           </div>
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="password">{t('auth.password')}</Label>
-              <span className="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
-                {t('auth.forgot')}
-              </span>
-            </div>
+            <Label htmlFor="password">{t('auth.password')}</Label>
             <div className="relative">
               <Input
                 id="password"

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import i18n from '@/lib/i18n';
 import { useUserPreferences } from '@/contexts/UserPreferencesContext';
+import { localeCurrency } from '@/lib/currency';
 import { useSearchParams } from 'react-router-dom';
 import {
   LogOut,
@@ -111,9 +112,9 @@ export default function Settings() {
     i18n.changeLanguage(lang);
     localStorage.setItem('preferredLanguage', lang);
     setLanguage(lang);
-    const localeCurrency = lang.startsWith('pt') ? 'BRL' : 'USD';
-    saveAndBroadcastCurrency(localeCurrency);
-    api.patch('/auth/me', { currency: localeCurrency }).catch(() => {
+    const currency = localeCurrency(lang);
+    saveAndBroadcastCurrency(currency);
+    api.patch('/auth/me', { currency }).catch(() => {
       /* best-effort */
     });
     toast.success(t('settings.languageSaved'));

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -12,19 +12,12 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-const signupSchema = z
-  .object({
-    name: z.string().min(1, 'Name is required'),
-    email: z.string().email('Please enter a valid email address'),
-    password: z.string().min(6, 'Password must be at least 6 characters'),
-    confirmPassword: z.string().min(1, 'Please confirm your password'),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Passwords do not match',
-    path: ['confirmPassword'],
-  });
-
-type SignupFormData = z.infer<typeof signupSchema>;
+interface SignupFormData {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
 
 export default function Signup() {
   const { t } = useTranslation();
@@ -32,6 +25,22 @@ export default function Signup() {
   const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  const signupSchema = useMemo(
+    () =>
+      z
+        .object({
+          name: z.string().min(1, t('validation.required', { field: t('auth.name') })),
+          email: z.string().email(t('validation.invalidEmail')),
+          password: z.string().min(6, t('validation.passwordMin')),
+          confirmPassword: z.string().min(1, t('validation.confirmPassword')),
+        })
+        .refine((data) => data.password === data.confirmPassword, {
+          message: t('validation.passwordsNoMatch'),
+          path: ['confirmPassword'],
+        }),
+    [t],
+  );
 
   const {
     register,

--- a/packages/shared/src/utils/plan.ts
+++ b/packages/shared/src/utils/plan.ts
@@ -1,6 +1,6 @@
 import type { FeatureFlags, UserPlan, PlanType, SubscriptionStatus } from '../types/index';
 
-const FREE_STATE = {
+const DISABLED_STATE = {
   plan: 'free' as PlanType,
   status: 'active' as SubscriptionStatus,
   isPro: false,
@@ -9,10 +9,11 @@ const FREE_STATE = {
   isCanceling: false,
   trialEndsAt: null as string | null,
   currentPeriodEnd: null as string | null,
+  isDisabled: true,
 };
 
 export function derivePlanState(plan: UserPlan | null | undefined, flags: FeatureFlags) {
-  if (!flags.billing) return FREE_STATE;
+  if (!flags.billing) return DISABLED_STATE;
 
   const p: UserPlan = plan ?? {
     plan: 'free',
@@ -31,5 +32,6 @@ export function derivePlanState(plan: UserPlan | null | undefined, flags: Featur
     isCanceling: p.cancelAtPeriodEnd,
     trialEndsAt: p.trialEndsAt,
     currentPeriodEnd: p.currentPeriodEnd,
+    isDisabled: false,
   };
 }


### PR DESCRIPTION
## Summary

Implements the fixes from the frontend audit (10 tasks), executed by a lower-cost model agent and reviewed/corrected before this PR.

### Auth & session
- **Network errors no longer log the user out** — tokens are only cleared when `auth.me` fails with `UNAUTHORIZED`/`FORBIDDEN`; transient network/server errors just resolve the loading state (`lib/auth.tsx`).
- **Single shared token refresh** — new `lib/tokenRefresh.ts` holds one in-flight refresh promise shared by the axios interceptor and the tRPC fetch wrapper. Concurrent 401s from either client now result in exactly one `POST /auth/refresh`, fixing the race with rotating refresh tokens.
- **Redirect back after login** — `ProtectedRoute` passes `state={{ from: location }}`; Login navigates back to the original page.
- **Cross-tab logout** — `storage` event listener logs out other tabs when the token is removed.
- Removed the dead "Forgot password" element on Login.

### i18n
- All 19 mutation/success toasts now go through i18next (`toasts.*` keys, en + pt-BR).
- Zod validation messages in Login, Signup, and TransactionForm are translated (`validation.*` keys), with field names interpolated from existing translated labels.

### Cleanups
- New `lib/currency.ts` (`SUPPORTED_CURRENCIES`, `localeCurrency`) replaces 5 duplicated inline mappings; the currency select renders from the constant.
- Dashboard error/retry now covers the previous-month summary and budgets queries.

### Billing flag (shared package)
- `derivePlanState` returns `isDisabled: true` when `featureFlags.billing` is off (no change to `PlanType`).
- The Editorial Insight upsell card is hidden when billing is disabled and the trend chart expands to full width — previously it showed an "Upgrade to Pro" CTA leading to a hidden Settings section.
- Mobile parity tracked in #6.

## Verification

- `frontend`: typecheck ✅, oxlint ✅ (0 warnings), vitest 98/98 ✅ (includes a new test for the hidden insight card and a new test asserting tokens survive non-auth `me` errors)
- `packages/shared`: typecheck ✅, vitest 88/88 ✅
- prettier formatting applied; pre-commit hook (turbo format:check) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)